### PR TITLE
fix grammar, trailing spaces, file organization

### DIFF
--- a/_bookdown.yml
+++ b/_bookdown.yml
@@ -11,23 +11,24 @@ language:
 
 rmd_files: [
   "index.Rmd",
-  
+
   "intro.Rmd",
-  
+
   "tlf-overview.Rmd",
   "tlf-disposition.Rmd",
   "tlf-population.Rmd",
   "tlf-baseline.Rmd",
-  "tlf-efficacy.Rmd", 
+  "tlf-efficacy.Rmd",
   "tlf-ae-summary.Rmd",
   "tlf-ae-spec.Rmd",
-  
+
+  "project-overview.Rmd",
   "project-folder.Rmd",
   "project-management.Rmd",
-  
+
   "submission-overview.Rmd",
   "submission-package.Rmd",
   "submission-environment.Rmd",
 
-  "reference.Rmd"
+  "references.Rmd"
 ]

--- a/book.bib
+++ b/book.bib
@@ -2,7 +2,7 @@
   title={{R} packages: organize, test, document, and share your code},
   author={Wickham, Hadley},
   year={2015},
-  publisher={" O'Reilly Media, Inc."}
+  publisher={O'Reilly Media}
 }
 
 @article{marwick2018packaging,
@@ -16,22 +16,25 @@
   publisher={Taylor \& Francis}
 }
 
-@article{wuanalysis,
+@conference{wuanalysis,
   title={Analysis and Reporting in Regulated Clinical Trial Environment using {R}},
   author={Wu, Peikun and Palukuru, Uday Preetham and Luo, Yiwen and Nepal, Sarad and Zhang, Yilong},
-  year={2021}
+  year={2021},
+  publisher = {PharmaSUG}
 }
 
-@article{madhutest,
+@conference{madhutest,
   title={A Process to Validate Internal Developed {R} Package under Regulatory Environment},
-  author={Ginnaram, Madhusudhan and Ye, Simiao and Zhu, Yalin and Zhang, Yilong}
+  author={Ginnaram, Madhusudhan and Ye, Simiao and Zhu, Yalin and Zhang, Yilong},
+  year={2021},
+  publisher = {PharmaSUG}
 }
 
 @book{teamgeek,
   title={Team geek: a software developer's guide to working well with others},
   author={Fitzpatrick, Brian and Collins-Sussman, Ben},
   year={2012},
-  publisher={" O'Reilly Media, Inc."}
+  publisher={O'Reilly Media}
 }
 
 @book{cleanarch,

--- a/index.Rmd
+++ b/index.Rmd
@@ -1,10 +1,10 @@
---- 
+---
 title: "R for Clinical Study Reports and Submission"
 author: ["Yilong Zhang", "Nan Xiao", "Keaven Anderson"]
 knit: "bookdown::render_book"
 description: >
   This book will teach you how to prepare tables, listings, and figures for
-  clinical study report and submit to regulatory agencies, 
+  clinical study report and submit to regulatory agencies,
   the essential part of clinical trial development.
 
 site: bookdown::bookdown_site
@@ -52,14 +52,14 @@ bookdown::render_book("index.Rmd", "bookdown::pdf_book")
 
 # Welcome! {-}
 
-<img src="images/cover.jpg" width="100%" align="right" alt="" class="cover" /> 
+<img src="images/cover.jpg" width="100%" align="right" alt="" class="cover" />
 
-Welcome to R for clinical study reports and submission. 
-Clinical study reports (CSR) are essential parts of clinical trial development. 
-A CSR is an "integrated" full scientific report of an individual clinical trial. 
+Welcome to R for clinical study reports and submission.
+Clinical study reports (CSR) are essential parts of clinical trial development.
+A CSR is an "integrated" full scientific report of an individual clinical trial.
 
-The [ICH E3: structure and content of clinical study reports](https://database.ich.org/sites/default/files/E3_Guideline.pdf) 
-provides guidance to assist sponsors in the development of a CSR. 
+The [ICH E3: structure and content of clinical study reports](https://database.ich.org/sites/default/files/E3_Guideline.pdf)
+provides guidance to assist sponsors in the development of a CSR.
 In this book, you will learn how to use R to prepare a CSR and
 how to submit it to regulatory agencies.
 

--- a/intro.Rmd
+++ b/intro.Rmd
@@ -2,78 +2,74 @@
 
 ## Folder structure
 
-In clinical trial development, source code needs to be developed and maintained to generate and deliver 
+In clinical trial development, source code needs to be developed and maintained to generate and deliver
 Study Data Tabulation Model (SDTM), Analysis Dataset Model (ADaM) datasets and tables, listings, and figures (TLFs).
-A typical example is a Phase 3 clinical trial where hundreds of TLFs are required for submission. 
-Considering the amount of programs required for such an effort, 
-a consistent and well-defined folder structure is crucial in 
-managing a clinical trial analysis and reporting (A&R) project. 
+A typical example is a Phase 3 clinical trial where hundreds of TLFs are required for submission.
+Considering the number of programs required for such an effort,
+a consistent and well-defined folder structure is crucial in
+managing a clinical trial analysis and reporting (A&R) project.
 
-We recommend using 
-[R package folder structure](https://github.com/rstudio/cheatsheets/raw/master/package-development.pdf) 
-to organize all the A&R related source code and documentation for a clinical trial A&R project. 
-The R package folder structure is well defined and widely used in R community through repositories (e.g. CRAN).
+We recommend using the
+[R package folder structure](https://github.com/rstudio/cheatsheets/raw/master/package-development.pdf)
+to organize all the A&R-related source code and documentation for a clinical trial A&R project.
+The R package folder structure is well defined and widely used in the R community through repositories (e.g., CRAN).
 
-The consistent approach of using R package folder structure 
+The consistent approach of using the R package folder structure
 simplifies the communication for all developers within and across organizations.
 
-- For a new R developer, 
-it is an essential step to develop R packages 
-when you want to share your work with others. 
-You will learn one folder structure that is widely used 
-in the R community with outstanding tutorials and tools for free. 
-
+- For a new R developer, it is an essential step to develop R packages
+  when you want to share your work with others.
+  You will learn one folder structure widely used in the R community
+  with outstanding tutorials and tools for free.
 - For an experienced R developer, there is a minimal learning curve.
+- For an organization, it simplifies the process, tool, template,
+  and training development, because a unified folder structure is used
+  to develop and maintain standard tool and analysis projects.
 
-- For an organization, it simplifies the process, tool, template, 
-and training development, because a unified folder structure is used 
-to develop and maintain standard tool and analysis projects.  
+The workflow around an R package can also improve
+the traceability and reproducibility of an analysis project [@marwick2018packaging].
 
-The workflow around an R package can also improve 
-the traceability and reproducibility for an analysis project [@marwick2018packaging].
+We will revisit folder structure when we discuss project management for a clinical trial project.
 
-We will revisit folder structure when we discuss project management for a clinical trial project.  
-
-In addition, R package folder structure is also recommended 
-to develop Shiny apps as discussed 
-in [Chapter 20 of Master Shiny](https://mastering-shiny.org/scaling-packaging.html) book 
-and [Engineering Production-Grade Shiny Apps](https://engineering-shiny.org/golem.html) book.   
+In addition, R package folder structure is also recommended
+to develop Shiny apps as discussed
+in [Chapter 20 of the Master Shiny book](https://mastering-shiny.org/scaling-packaging.html)
+and the [Engineering Production-Grade Shiny Apps](https://engineering-shiny.org/golem.html) book.
 
 ## In this book
 
-This book is an intermediate-level book by 
+This book is an intermediate-level book by
 assuming readers have R programming and clinical development knowledge.
 The assumption of each part is as below:
 
-- Part 1, "Delivering TLFs in CSR" provides general information with examples 
-to create tables, listings, and figures. 
-In this part, we assume readers are individual contributors to a clinical project
-with some experience in R programming. 
-We expect readers are familiar with data manipulation in R. 
-Some good references include [Hands-On Programming with R](https://rstudio-education.github.io/hopr/),
-[R for Data Science](https://r4ds.had.co.nz/) and 
-[Data Manipulation with R](https://www.amazon.com/Data-Manipulation-R-Use/dp/0387747303).
+- Part 1, "Delivering TLFs in CSR" provides general information with examples
+  to create tables, listings, and figures.
+  In this part, we assume readers are individual contributors to a clinical project
+  with some experience in R programming.
+  We expect readers are familiar with data manipulation in R.
+  Some good references include [Hands-On Programming with R](https://rstudio-education.github.io/hopr/),
+  [R for Data Science](https://r4ds.had.co.nz/) and
+  [Data Manipulation with R](https://www.amazon.com/Data-Manipulation-R-Use/dp/0387747303).
 
-- Part 2, "Clinical Trial Project" provides general information 
-with examples to manage a clinical trial A&R project. 
-In this part, we assume a reader is a project lead with experience in R package development. 
-Some good reference includes [R packages](https://r-pkgs.org/) and 
-[The tidyverse style guide](https://style.tidyverse.org/). 
+- Part 2, "Clinical trial project" provides general information
+  with examples to manage a clinical trial A&R project.
+  In this part, we assume a reader is a project lead with experience in R package development.
+  Some good references include [R Packages](https://r-pkgs.org/) and
+  [The tidyverse style guide](https://style.tidyverse.org/).
 
-- Part 3, "eCTD submission package"
-provides general information in preparing 
-submission package related to clinical study report (CSR) in 
-electronic Common Technical Document (eCTD). 
-In this part, we assume a reader is a project lead of a clinical project 
-with experience in R package development and submission.     
+- Part 3, "eCTD submission package" provides general information in preparing
+  submission packages related to clinical study report (CSR) in
+  electronic Common Technical Document (eCTD).
+  In this part, we assume a reader is a project lead of a clinical project
+  with experience in R package development and submission.
 
-## Philosophy 
+## Philosophy
 
-We share the same philosophy described in 
-[Section 1.1 of R Packages book](https://r-pkgs.org/intro.html#intro-phil) 
+We share the same philosophy described in
+[Section 1.1 of the R Packages book](https://r-pkgs.org/intro.html#intro-phil)
 and quote here.
 
-- "Anything that can be automated, should be automated." 
-- "Do as little as possible by hand. Do as much as possible with functions." 
-- "The goal is to spend your time thinking about what you want to do 
+- "Anything that can be automated, should be automated."
+- "Do as little as possible by hand. Do as much as possible with functions."
+- "The goal is to spend your time thinking about what you want to do
 rather than thinking about the minutiae of the package structure."

--- a/project-folder.Rmd
+++ b/project-folder.Rmd
@@ -1,80 +1,64 @@
-# (PART) Clinical trial project {-}
-
-# Overview
-
-In a late-stage clinical trial, the number of A&R deliverables can easily be in the hundreds. 
-For an organization, it is common to have multiple ongoing clinical trials in a clinical program. 
-
-To deliver the A&R results of a clinical trial project, 
-it is a teamwork that typically requires collaborations from both statisticians and programmers. 
-In this part, let's consider how to organize a clinical trial project as an A&R leader. 
-
-In Chapter \@ref(folder), we will discuss how to organize source code, documents, deliverables in an A&R clinical project. 
-We recommend using the R package folder structure. 
-
-In Chapter \@ref(manage), we will discuss a process or system development lifecycle 
-to manage the A&R of a clinical project. 
-We recommend following an agile management approach to define, develop, validate and deliver work.
-
 # Project folder {#folder}
 
-A clearly defined clinical project folder structure can have many benefits to clinical development teams in an organization. 
+A clearly defined clinical project folder structure can have many benefits to clinical development teams in an organization.
 Specifically, a well-defined project structure can achieve:
 
 - Consistency: everyone works on the same folder structure.
-- Reproducibility: analysis can be executed and reproduced by different team members months/years later.  
-- Automation: automatically check the integration of a project.  
-- Compliance: reduce compliance issue
+- Reproducibility: analysis can be executed and reproduced by different team members months/years later.
+- Automation: automatically check the integration of a project.
+- Compliance: reduce compliance issues.
 
-We illustrate the R package project folder for the A&R project using a demo project called 
-[`esubdemo`](https://github.com/elong0527/esubdemo.git). 
-You can [clone](https://happygitwithr.com/rstudio-git-github.html#clone-the-new-github-repository-to-your-computer-via-rstudio) the project using RStudio. 
+We illustrate the R package project folder for the A&R project using a demo project called
+[`esubdemo`](https://github.com/elong0527/esubdemo.git).
+You can
+[clone](https://happygitwithr.com/rstudio-git-github.html#clone-the-new-github-repository-to-your-computer-via-rstudio)
+the project using RStudio.
 
-For R users, you already benefit from a well-defined and consistent folder structure. 
-That is the [R package folder structure](https://github.com/rstudio/cheatsheets/raw/master/package-development.pdf). 
-Every R package developer is required to follow the same convention to organize 
-their R functions before the R package can be disseminated through the Comprehensive R Archive Network (CRAN). 
-As a user, you can easily install and use those R packages after installing from CRAN. 
-There are many good resources to guide developers on R package development.
-For example, Hadley Wickham's [R Packages book](https://r-pkgs.org/).
+For R users, you already benefit from a well-defined and consistent folder structure.
+That is the [R package folder structure](https://github.com/rstudio/cheatsheets/raw/master/package-development.pdf).
+Every R package developer is required to follow the same convention to organize
+their R functions before the R package can be disseminated through the Comprehensive R Archive Network (CRAN).
+As a user, you can easily install and use those R packages after installing from CRAN.
+There are many good resources to guide developers on R package development,
+for example, the [R Packages book](https://r-pkgs.org/) by Hadley Wickham.
 
-We recommend using the R package folder structure to organize analysis scripts for clinical trial development. 
-Using the R package folder structure to streamline data analysis work has also been proposed before 
-(see @marwick2018packaging, @wuanalysis). 
+We recommend using the R package folder structure to organize analysis scripts for clinical trial development.
+Using the R package folder structure to streamline data analysis work has also been proposed before
+(see @marwick2018packaging, @wuanalysis).
 
 ## Consistency {#consistency}
 
 For consistency, a well-defined folder structure with potential templates
-ensures project teams organize the A&R work consistently across multiple projects. 
-Consistent folder structure also reduces communication costs 
+ensures project teams organize the A&R work consistently across multiple projects.
+Consistent folder structure also reduces communication costs
 between study team members and enhances the transparency of projects.
 
-In this book, we refer to an R package as **project-specific R package** 
+In this book, we refer to an R package as a **project-specific R package**
 if the purpose of an R package is to organize analysis scripts for a clinical project.
 
-We refer to an R package as a **standard R package** if the purpose of an R package is 
-to share commonly used R functions to be hosted in a code repository such as CRAN. 
+We refer to an R package as a **standard R package** if the purpose of an R package is
+to share commonly used R functions to be hosted in a code repository such as CRAN.
 
 Below is minimal sufficient folders and files for a project-specific R package
-based on the R package folder structure.  
+based on the R package folder structure.
 
 - `*.Rproj`: RStudio project file used to open RStudio project.
 - `DESCRIPTION`: Metadata for a package including authors, license, dependencies, etc.
 - `R/`: Project-specific R functions.
-- `vignettes/`: Analysis scripts using Rmarkdown.
+- `vignettes/`: Analysis scripts using R Markdown.
 - `man/`: Manual of project-specific R functions.
 
-A general discussion of the R package folder structure can be found 
-in Chapter 4 of the R package book (@wickham2015r).
+A general discussion of the R package folder structure can be found
+in Chapter 4 of the R Packages book (@wickham2015r).
 
 We demonstrate the idea using the [`esubdemo`](https://github.com/elong0527/esubdemo) project.
 
-In the `esubdemo` project, we saved all TLF generation scripts in previous chapters into the `vignettes/` folder. 
+In the `esubdemo` project, we saved all TLF generation scripts in previous chapters into the `vignettes/` folder.
 
 > Under the `vignettes/` folder, there are `adam/` folder and `tlf` folder.
-> The `adam/` folder contains ADaM datasets. 
+> The `adam/` folder contains ADaM datasets.
 > The `tlf` folder contains output TLFs in RTF format.
-> We put `adam/` and `tlf/` folders within the `vignettes` folder only for illustration purposes. 
+> We put `adam/` and `tlf/` folders within the `vignettes` folder only for illustration purposes.
 > In an actual A&R report, you may have a different location to save your input and output.
 
 ```
@@ -89,8 +73,8 @@ vignettes
 └── tlf-06-ae-spec.Rmd
 ```
 
-While creating those analysis scripts, we also defined a few helper functions (e.g. `fmt_num` and `count_by`). 
-Those functions are saved in the `R/` folder. 
+While creating those analysis scripts, we also defined a few helper functions (e.g., `fmt_num` and `count_by`).
+Those functions are saved in the `R/` folder.
 
 ```
 R/
@@ -98,10 +82,10 @@ R/
 └── fmt.R
 ```
 
-With a formal project, it is also important to provide proper documentation for those help functions. 
-We used Roxygen2 to document functions. 
-For example, the header below defines each variable in `fmt_est`. 
-More details can be found in [Chapter 10 of the R package book](https://r-pkgs.org/man.html)
+With a formal project, it is also important to provide proper documentation for those help functions.
+We used `roxygen2` to document functions.
+For example, the header below defines each variable in `fmt_est`.
+More details can be found in [Chapter 10 of the R Packages book](https://r-pkgs.org/man.html).
 
 ```{r, eval = FALSE}
 #' Format point estimator
@@ -120,9 +104,9 @@ fmt_est <- function(.mean,
 }
 ```
 
-Those `Roxygen2` documentation will be transferred to 
-standard R documentation `.Rd` files saved in the `man/` folder. 
-This step is automatically handled by `devtools::document()` function.
+The `roxygen2` documentation will be converted into
+standard R documentation format, saved as `.Rd` files in the `man/` folder.
+This step is automatically handled by `devtools::document()`.
 
 ```
 man
@@ -133,48 +117,48 @@ man
 └── fmt_pval.Rd
 ```
 
-The `man` folder is used to save documentation automatically generated by `roxygen2`.
-A typical workflow is to add `roxygen2` documentation at the header of each function in the `R/` folder. 
-Then `devtools::documents()` is used to generate all the documentation files in the `man/` folder. 
-More details can be found in [Chapter 10 of the R packages book](https://r-pkgs.org/man.html). 
-
+The `man/` folder is used to save documentation automatically generated by `roxygen2`.
+A typical workflow is to add `roxygen2` documentation before each function in the `R/` folder.
+Then `devtools::documents()` is used to generate all the documentation files in the `man/` folder.
+More details can be found in [Chapter 10 of the R Packages book](https://r-pkgs.org/man.html).
 
 ## Reproducibility {#reproduce}
 
-Reproducibility of analysis is one of the most important aspects of regulatory deliverables. 
-To ensure a successful reproduce, we need a controlled R environment, 
-including the control of R version and control of R package version.  
-By using the R package folder structure and proper tools (e.g. `renv`, `packrat`), 
-we illustrate how to achieve reproducibility for R and R package versions. 
+Reproducibility of analysis is one of the most important aspects of regulatory deliverables.
+To ensure a successful reproduce, we need a controlled R environment,
+including the control of the R version and the R package versions.
+By using the R package folder structure and proper tools (e.g., `renv`, `packrat`),
+we illustrate how to achieve reproducibility for R and R package versions.
 
 > This is the same level of reproducibility in most SAS environments.
 > https://support.sas.com/techsup/pcn/altopsys.html
 
-First, we introduce the control of R version. 
-In the `esubdemo` project, a reproducible environment is created when you open the 
-`esubdemo.Rproj` from RStudio. 
+First, we introduce the control of the R version.
+In the `esubdemo` project, a reproducible environment is created when you open
+the `esubdemo.Rproj` from RStudio.
 When we open the `esubdemo` project, RStudio will execute the R code in `.Rprofile` automatically.
-So we can use `.Rprofile` to set up a reproducible environment. 
-More details can be found in [https://rstats.wtf/r-startup.html](https://rstats.wtf/r-startup.html). 
-After we open the `esubdemo` project, the code in `.Rprofile` will 
+So we can use `.Rprofile` to set up a reproducible environment.
+More details can be found in <https://rstats.wtf/r-startup.html>.
+After we open the `esubdemo` project, the code in `.Rprofile` will
 automatically check the current R version is the same as we defined in `.Rprofile`.
+
 ```{r, eval = FALSE}
-# set up project R version
+# Set project R version
 R_version <- "4.1.1"
 ```
+
 If the R version mismatch, an error message is displayed as below.
 
 ```
 Error: The current R version is not the same as the current project in R4.1.1
 ```
 
-> `.Rprofile` is only for project-specific R package. 
-> A standard R package should not use `.Rprofile`.   
+> `.Rprofile` is only for project-specific R packages.
+> A standard R package should not use `.Rprofile`.
 
-
-Next, we introduce the control of R package version, which is controlled in two layers. 
-Firstly, we define a snapshot date in `.Rprofile`. 
-The snapshot date allows us to freeze the source code repository. 
+Next, we introduce the control of the R package version, which is controlled in two layers.
+Firstly, we define a snapshot date in `.Rprofile`.
+The snapshot date allows us to freeze the source code repository.
 
 ```{r, eval = FALSE}
 # set up snapshot date
@@ -188,119 +172,119 @@ options(repos = repos)
 ```
 
 We can also define the package repository to be a specific snapshot date.
-For example, we used Microsoft R Application Network (MRAN) to 
-define the snapshot date to be `2021-08-06`. 
-The snapshot date freezes the R package repository. 
+For example, we used Microsoft R Application Network (MRAN) to
+define the snapshot date to be `2021-08-06`.
+The snapshot date freezes the R package repository.
 
-In other words, all R packages installed in this RStudio project 
-are based on the frozen R version at the snapshot date. 
+In other words, all R packages installed in this RStudio project
+are based on the frozen R version at the snapshot date.
 Here it is `2021-08-06` by using the MRAN server.
 
-Below information will be displayed after a new R session is opened. 
+Below information will be displayed after a new R session is opened.
 
 ```
 Current project R package repository:
     https://mran.microsoft.com/snapshot/2021-08-06
 ```
 
-> RStudio Package Manager (RSPM) provided a solution to host both 
-> publicly available and internally developed R packages. 
-> However, the public RSPM server (https://packagemanager.rstudio.com/client/#/repos/2/overview) 
-> did not provide a daily snapshot as MRAN had. 
+> RStudio Package Manager (RSPM) provided a solution to host both
+> publicly available and internally developed R packages.
+> However, the public RSPM server (https://packagemanager.rstudio.com/client/#/repos/2/overview)
+> did not provide a daily snapshot as MRAN had.
 
 Secondly, we use `renv` to lock R package versions and save them in the `renv.lock` file.
-`renv` provides a robust and stable approach to managing R package versions 
+`renv` provides a robust and stable approach to managing R package versions
 for project-specific R packages.
-An introduction of `renv` can be found on its 
+An introduction of `renv` can be found on its
 [website](https://rstudio.github.io/renv/articles/renv.html).
 
 ```{r, eval = FALSE}
 source("renv/activate.R")
 ```
 
-The R code above in the `.Rprofile` initiates the `renv` running environment.  
-As a user, you can use `renv::init()`, `renv::snapshot()` and `renv::restore()` 
-to initialize, save and restore R packages used for the current analysis project. 
+The R code above in the `.Rprofile` initiates the `renv` running environment.
+As a user, you can use `renv::init()`, `renv::snapshot()`, and `renv::restore()`
+to initialize, save and restore R packages used for the current analysis project.
 
-In the analysis project, the `renv` package will 
+In the analysis project, the `renv` package will
 
 - create a `renv.lock` file to save the state of package versions.
-- create a `renv` folder to manage R packages for a project. 
+- create a `renv` folder to manage R packages for a project.
 
-> `renv.lock` file and `renv/` folder are only for project-specific R package.
-> A standard R package should not use `renv`.  
+> The `renv.lock` file and `renv/` folder are only for project-specific R package.
+> A standard R package should not use `renv`.
 
-In summary, the R package version is controlled in two layers. 
+In summary, the R package version is controlled in two layers.
 
 - Define a snapshot date in `inst/startup.R`.
-- Using `renv` to lock R versions within a project. 
+- Using `renv` to lock R versions within a project.
 
-If the project is initiated properly, 
-you shall be able to see similar messages to inform how we control R package versions. 
+If the project is initiated properly,
+you shall be able to see similar messages to inform how we control R package versions.
 
 ```
 * Project '~/esubdemo' loaded. [renv 0.14.0]
 ```
 
-Once R packages have been properly installed, 
-the system will use the R packages located in the search path 
+Once R packages have been properly installed,
+the system will use the R packages located in the search path
 defined based on the order of `.libPaths()`.
-The startup message also provided the R package search path. 
+The startup message also provided the R package search path.
 
 ```
-Below R package path are searching in order to find installed R pacakges in this R session:
+Below R package path are searching in order to find installed R packages in this R session:
     "/home/zhanyilo/github-repo/esubdemo/renv/library/R-4.1/x86_64-pc-linux-gnu"
-    "/rtmp/RtmpT3ljoY/renv-system-library"   
+    "/rtmp/RtmpT3ljoY/renv-system-library"
 ```
 
 > A cloud-based R environment (e.g., RStudio Workbench)
 > can enhance the reproducibility within an organization
 > by using the same operating system, R version, and R package versions for an A&R project.
-> More details can be found in [https://environments.rstudio.com/](https://environments.rstudio.com/).
+> More details can be found at <https://environments.rstudio.com/>.
 
-> A container solution like [Docker](https://github.com/rstudio/r-docker) could further enhance 
-> the reproducibility across an organization at the operating system level, but beyond the scope of this book.
+> A container solution like [Docker](https://github.com/rstudio/r-docker) could further enhance
+> the reproducibility across an organization at the operating system level but beyond the scope of this book.
 
-In conclusion, to achieve reproducibility for a project-specific R package, 
-a clinical project team can work under a controlled R environment 
+In conclusion, to achieve reproducibility for a project-specific R package,
+a clinical project team can work under a controlled R environment
 in the same R version and R package versions defined by a repository snapshot date.
 
-## Automation 
+## Automation
 
-By using the R package folder structure, you will benefit from many outstanding tools to 
-simplify and streamline your workflow. 
+By using the R package folder structure, you will benefit from many outstanding tools to
+simplify and streamline your workflow.
 
 We have learned a few functions in `devtools` to generate content automatically.
-Here is a shortlist of tools that can enhance the workflow. 
+Here is a shortlist of tools that can enhance the workflow.
 
-- [`devtools`](https://devtools.r-lib.org/): make package development easier. 
-  + A good overview can be found in [Chapter 2 of the R packages](https://r-pkgs.org/whole-game.html) book  
-  + `devttols::load_all()`: load all functions in `R/` folder and running environment. 
+- [`devtools`](https://devtools.r-lib.org/): make package development easier.
+  + A good overview can be found in [Chapter 2 of the R Packages book](https://r-pkgs.org/whole-game.html).
+  + `devttols::load_all()`: load all functions in `R/` folder and running environment.
   + `devtools::document()`: automatically create documentation using `roxygen2`.
-  + `devttols::check()`: automatically perform compliance check as an R package. 
-  + `devtools::build_site()`: automatically run analysis scripts in batch and create a `pkgdown` website. 
+  + `devttols::check()`: automatically perform compliance check as an R package.
+  + `devtools::build_site()`: automatically run analysis scripts in batch and create a `pkgdown` website.
 - [`usethis`](https://usethis.r-lib.org/): automates repetitive tasks that arise during project setup and development.
 - [`testthat`](https://testthat.r-lib.org/): streamline testing code.
-  + A discussion of using the `testthat` for an A&R project can be found in (@madhutest).  
+  + A discussion of using the `testthat` for an A&R project can be found in (@madhutest).
 - [`pkgdown`](https://pkgdown.r-lib.org/): generate static HTML documentation website for an R package
-  + It also allows you to run all analysis code in batch. 
+  + It also allows you to run all analysis code in batch.
 
-You may further automatically execute routines by leveraging CI/CD workflow. 
+You may further automatically execute routines by leveraging CI/CD workflow.
 For example, the `esubdemo` project will rerun all required checks and build a pkgdown website
 by using [Github Actions](https://usethis.r-lib.org/reference/github_actions.html).
 
-As the consistent folder is defined, it also becomes easier to create specific tools 
-that fit for the analysis and reporting purpose. Below are few potential tools that can be helpful:
+As the consistent folder is defined, it also becomes easier to create specific tools
+that fit the analysis and reporting purpose. Below are a few potential tools that can be helpful:
 
 - Create project template using [RStudio Project Templates](https://rstudio.github.io/rstudio-extensions/rstudio_project_templates.html)
-- Add additional compliance checks for analysis and reporting. 
-- Save log files for running in batch. 
+- Add additional compliance checks for analysis and reporting.
+- Save log files for running in batch.
 
 ## Compliance
 
-For a regulatory deliverable, it is important to maintain compliance. 
-With a consistent folder structure, we can define specific criteria for compliance. 
-Some compliance criteria can be implemented within the automatically checking steps. 
+For a regulatory deliverable, it is important to maintain compliance.
+With a consistent folder structure, we can define specific criteria for compliance.
+Some compliance criteria can be implemented within the automatically checking steps.
 
-For an R package, there are already criteria to ensure R package integrity.  
-More details can be found in [Chapter 19 of the R package book](https://r-pkgs.org/r-cmd-check.html).
+For an R package, there are already criteria to ensure R package integrity.
+More details can be found in [Chapter 19 of the R Packages book](https://r-pkgs.org/r-cmd-check.html).

--- a/project-management.Rmd
+++ b/project-management.Rmd
@@ -2,38 +2,38 @@
 
 ## Setting up for success
 
-A clinical data analysis project is not unlike typical data analysis projects or software projects. 
+A clinical data analysis project is not unlike typical data analysis projects or software projects.
 Therefore, the conventional wisdom and tricks for managing a successful project are also applicable here.
-At the same time, clinical projects also have unique traits, 
-such as high standards for planning, development, validation, and delivery 
+At the same time, clinical projects also have unique traits,
+such as high standards for planning, development, validation, and delivery
 under strict time constraints.
 
 Although many factors could decide if a project could execute efficiently,
-we believe a few aspects are critical for the long-term success,
+we believe a few aspects are critical for long-term success,
 especially when managing clinical data analysis projects at scale.
 
 ### Work as a team
 
 As a general principle, all the team members involved in a project
 should take basic training on project management and understand how to work as
-a development team. 
+a development team.
 @teamgeek provides some valuable tips on this topic.
 As always, setting a clear goal and following a system development lifecycle
-(SDLC) are essential.
+(SDLC) is essential.
 
 ### Design clean code architecture
 
 Having a clean architecture design for your code improves the project's
-robustness and flexibility for future changes. 
+robustness and flexibility for future changes.
 For example, we should understand how to separate business logic from other layers;
 know what should be created as reusable components and what should be
 written as one-off analysis scripts; write low coupling, high cohesion code,
-and so on. 
+and so on.
 @cleanarch offers some helpful insights on this topic.
 
 ### Set capability boundaries
 
-Knowing what you can do is essential. 
+Knowing what you can do is essential.
 Create a core capabilities list for your team.
 
 Sometimes, it is also critical to understand **what not to do**.
@@ -44,45 +44,45 @@ a complex solution that requires high maintenance and constant attention.
 
 ### Contribute to the community
 
-Every individual is limited in some way. 
+Every individual is limited in some way.
 The collective thinking from a community could benefit a project in the long term.
 When designing reusable components, make a plan to share with
 internal communities, or even better, with the open-source community.
 
 ## The SDLC
 
-For A&R deliverables in clinical project development, 
-a clearly defined process or system development lifecycle (SDLC) 
-is crucial to ensure regulatory compliance. 
+For A&R deliverables in clinical project development,
+a clearly defined process or system development lifecycle (SDLC)
+is crucial to ensure regulatory compliance.
 
-SDLC for the A&R deliverables can be defined in four stages: 
+SDLC for the A&R deliverables can be defined in four stages.
 
-- planning: a planning stage to define the scope of a project.  
-- development: a development stage to implement target deliverables. 
-- validation: a validation stage to verify target deliverables. 
-- operation: an operation stage to deliver work to stakeholders. 
+- Planning: a planning stage to define the scope of a project.
+- Development: a development stage to implement target deliverables.
+- Validation: a validation stage to verify target deliverables.
+- Operation: an operation stage to deliver work to stakeholders.
 
-Importantly, we should not consider SDLC as a linear process. 
-For example, if the study team identifies new requirement in a development or validation stage, 
-the team should return to the planning stage to discuss and align the scope. 
-An [agile project management](https://www.atlassian.com/agile/project-management) approach is suitable 
-and recommended to an A&R clinical development project.
+Importantly, we should not consider SDLC as a linear process.
+For example, if the study team identifies a new requirement in a development or validation stage,
+the team should return to the planning stage to discuss and align the scope.
+An [agile project management](https://www.atlassian.com/agile/project-management) approach is suitable
+and recommended for an A&R clinical development project.
 The goal is to embrace an iterative approach that continuously improves target deliverables based on
-frequent stakeholder feedback. 
+frequent stakeholder feedback.
 
 There are many good tools to implement agile project management strategy, for example:
 
 - [GitHub project board](https://docs.github.com/en/issues/organizing-your-work-with-project-boards/managing-project-boards/about-project-boards)
 - [Jira](https://www.atlassian.com/software/jira)
 
-## Planning 
+## Planning
 
-The planning stage is important in the SDLC lifecycle 
-as the requirements for all A&R deliverables are gathered and documented. 
+The planning stage is important in the SDLC lifecycle
+as the requirements for all A&R deliverables are gathered and documented.
 
-In the planning stage, a project leader should identify all the deliverables, 
-e.g., a list of tables, listings, and figures (TLFs). 
-For each TLFs, the team should prepare the necessary specifications: 
+In the planning stage, a project leader should identify all the deliverables,
+e.g., a list of tables, listings, and figures (TLFs).
+For each TLFs, the team should prepare the necessary specifications:
 
 - mock-up tables
 - validation level (e.g., independent review or double programming)
@@ -95,61 +95,61 @@ The purpose is to answer the question of "who is doing what?"
 knitr::include_graphics("images/validation_tracker.png")
 ```
 
-The project lead should also set up a project folder as discussed in Chapter \@ref(folder).
-The project initiation can be simplified by creating an 
-[RStudio project template](https://rstudio.github.io/rstudio-extensions/rstudio_project_templates.html).  
+The project lead should also set up a project folder, as discussed in Chapter \@ref(folder).
+The project initiation can be simplified by creating an
+[RStudio project template](https://rstudio.github.io/rstudio-extensions/rstudio_project_templates.html).
 
-To enable reproducibility, the project leader should also review the startup file 
+To enable reproducibility, the project leader should also review the startup file
 (i.e. `.Rprofile` discussed in Section \@ref(reproduce)) and define:
 
-- R version 
-- Repository of R packages with a snapshot date 
-- Project package library path 
-- etc. 
+- R version
+- Repository of R packages with a snapshot date
+- Project package library path
+- etc.
 
-> After project initiation, modifying `.Rprofile` will be a risk of reproducibility 
-> and should be handled carefully if necessary. 
+> After project initiation, modifying `.Rprofile` will be a risk of reproducibility
+> and should be handled carefully if necessary.
 
-## Development 
+## Development
 
-After a project is initiated, the study team start to develop TLFs based on 
-pre-defined mock-up tables assigned to each team member. 
+After a project is initiated, the study team starts to develop TLFs based on
+pre-defined mock-up tables assigned to each team member.
 
-The analysis code and relevant description can be saved in R markdown files 
-in the `vignettes` folder. 
+The analysis code and relevant description can be saved in R Markdown files
+in the `vignettes` folder.
 
-The use of R markdown allows developers to assemble narrative text, code, and its
-comments in one place to simplify documentation. 
-It would be helpful to create a template and define a name convention for all TLFs deliverables. 
-For example, we can use `tlf_` prefix in the filename to indicate that the R Markdown is to deliver TLFs. 
-Multiple TLFs with similar designs can be included in one R Markdown file. 
+The use of R Markdown allows developers to assemble narrative text, code, and its
+comments in one place to simplify documentation.
+It would be helpful to create a template and define a name convention for all TLFs deliverables.
+For example, we can use the `tlf_` prefix in the filename to indicate that the R Markdown file is for delivering TLFs.
+Multiple TLFs with similar designs can be included in one R Markdown file.
 
-For example, in `esubdemo` project, we have 6 R Markdown files to create TLFs. 
+For example, in the `esubdemo` project, we have 6 R Markdown files to create TLFs.
 
-If there is any project-specific R functions that need to be developed, 
+If there are any project-specific R functions that need to be developed,
 the R functions can be placed in the `R/` folder as discussed in Section \@ref(consistency).
 
-## Validation 
+## Validation
 
-Validation is an crucial stage to ensure the deliverables are accurate and consistent. 
+Validation is a crucial stage to ensure the deliverables are accurate and consistent.
 After the development stage is completed, the project team needs to validate the deliverables, including R Markdown
-files for TLFs deliverables and project-specific R functions. 
-The level of validation is determined at the define stage. 
+files for TLFs deliverables and project-specific R functions.
+The level of validation is determined at the define stage.
 
-In an R package development, the validation or testing is completed under the `test/` folder. 
-The testthat R package can be used to streamline the validation process. 
-More details of the `testthat` package for R package validation can be found in [Chapter 12 of the R package book](https://r-pkgs.org/tests.html). 
+In an R package development, the validation or testing is completed under the `test/` folder.
+The testthat R package can be used to streamline the validation process.
+More details of the `testthat` package for R package validation can be found in [Chapter 12 of the R package book](https://r-pkgs.org/tests.html).
 
-It is recommended to have a name convention to indicate the type of validation. 
-For example, we can use `test-developer-test`, `test-independent-test`, `test-double-programming` 
-to classify the validation type. 
+It is recommended to have a name convention to indicate the type of validation.
+For example, we can use `test-developer-test`, `test-independent-test`, `test-double-programming`
+to classify the validation type.
 
 It is recommended to follow the same organization
-for files in testthat folder as `R/` folder and `vignettes/` folder. 
-Every single file in the `R/` folder and `vignettes/` folder should have a testing file saved in 
+for files in testthat folder as `R/` folder and `vignettes/` folder.
+Every single file in the `R/` folder and `vignettes/` folder should have a testing file saved in
 the `tests/testthat/` folder to validate the content.
 
-For example, in `esubdemo` project, we can have a list of testing files below. 
+For example, in `esubdemo` project, we can have a list of testing files below.
 
 ```
 tests/testthat
@@ -163,43 +163,42 @@ tests/testthat
 ```
 
 To validate the content of a table, we can save the last datasets ready for table generation as a `.Rdata` file.
-A validator can reproduce the TLF and compares it with the original result saved in `.Rdata` file. 
-A test is passed when the results match. 
-Customers can directly review the formatting of the TLFs by
-customers by comparing them with the mock-up.
+A validator can reproduce the TLF and compare it with the original result saved in the `.Rdata` file.
+A test is passed when the results match.
+Customers can directly review the formatting of the TLFs by comparing them with the mock-up.
 
-To validate a figure, we can use [snapshot testing](https://testthat.r-lib.org/articles/snapshotting.html) strategy.
+To validate a figure, we can use the [snapshot testing](https://testthat.r-lib.org/articles/snapshotting.html) strategy.
 
-After the validator completes the testing of project-specific functions and R Markdown files, 
-the process to execute and report testing results is the same for a standard R package. 
-The `devtools::test()` function automatically executes all testing cases and summarizes the testing results in a report. 
+After the validator completes the testing of project-specific functions and R Markdown files,
+the process to execute and report testing results is the same for a standard R package.
+The `devtools::test()` function automatically executes all testing cases and summarizes the testing results in a report.
 
-After completing the validation, the validator updates the status in a validation tracker. 
-The project lead reviews the tracking sheet to make sure all required activities in the SDLC are completed and
-the tracking sheet has been filled correctly. 
-The deliverables are ready for customer review after all the validation steps are completed. 
+After completing the validation, the validator updates the status in a validation tracker.
+The project lead reviews the tracking sheet to make sure all required activities in the SDLC are completed,
+and the tracking sheet has been filled correctly.
+The deliverables are ready for customer review after all the validation steps are completed.
 Any changes to the output requested by customers are documented.
 
-## Operation 
+## Operation
 
-After completion of development and required validation of all A&R deliverables, 
-project lead runs compliance check for a project-specific R package similar to other R packages. 
-`devtools::check()` is a convenient way to run compliance checks or `R CMD check`. 
-`R CMD check` is an automated check of the contents in the R package 
-for frequently encountered issues, before submission to CRAN. 
-Since the project-specific R package is not submitted to CRAN, some checks can be customized and skipped in `devtools::check()`. 
-The project lead should work with the study team to ensure 
-all reported errors, warnings, and notes by `devtools::check()` are fixed. 
+After completion of development and required validation of all A&R deliverables,
+the project lead runs compliance checks for a project-specific R package similar to other R packages.
+`devtools::check()` is a convenient way to run compliance checks or `R CMD check`.
+`R CMD check` is an automated check of the contents in the R package
+for frequently encountered issues before submission to CRAN.
+Since the project-specific R package is not submitted to CRAN, some checks can be customized and skipped in `devtools::check()`.
+The project lead should work with the study team to ensure
+all reported errors, warnings, and notes by `devtools::check()` are fixed.
 
-The project lead can also use the R package `pkgdown` to build a complete website for a project-specific R package. 
-The `pkgdown` website is a convenient way to run all analyses in batch and 
-integrate outputs in a website, which comprehensively covers 
-project-specific R functions, TLF generation programs, outputs and validation tracking information, etc... 
+The project lead can also use the R package `pkgdown` to build a complete website for a project-specific R package.
+The `pkgdown` website is a convenient way to run all analyses in batch and
+integrate outputs in a website, which comprehensively covers
+project-specific R functions, TLF generation programs, outputs and validation tracking information, etc.
 For example, in the `esubdemo` project, we created the `pkgdown` website at <https://elong0527.github.io/esubdemo/>.
 
-Many of the tasks in SDLC can be completed automatically. 
-An organization can leverage CI/CD workflow to automatically enable those tasks 
-such as running testing cases and creating a `pkgdown` website. 
-For example, in `esubdemo` project, we setup [GitHub Actions](https://github.com/elong0527/esubdemo/actions)
-for these work.
-It can be setup by using `usethis::use_github_action()` function.
+Many of the tasks in SDLC can be completed automatically.
+An organization can leverage CI/CD workflow to automatically enable those tasks,
+such as running testing cases and creating a `pkgdown` website.
+For example, in the `esubdemo` project, we set up
+[GitHub Actions](https://github.com/elong0527/esubdemo/actions)
+for it. This can be done by using `usethis::use_github_action()`.

--- a/project-overview.Rmd
+++ b/project-overview.Rmd
@@ -1,0 +1,18 @@
+# (PART) Clinical trial project {-}
+
+# Overview {#project-overview}
+
+In a late-stage clinical trial, the number of A&R deliverables can easily be in the hundreds.
+For an organization, it is common to have multiple ongoing clinical trials in a clinical program.
+
+To deliver the A&R results of a clinical trial project,
+it is teamwork that typically requires collaborations from both statisticians and programmers.
+In this part, let's consider how to organize a clinical trial project as an A&R lead.
+
+Chapter \@ref(folder) will discuss how to organize source code, documents, and
+deliverables in an A&R clinical project.
+We recommend using the R package folder structure.
+
+Chapter \@ref(manage) will discuss a process or system development lifecycle
+to manage the A&R of a clinical project.
+We recommend following an agile management approach to define, develop, validate, and deliver work.

--- a/references.Rmd
+++ b/references.Rmd
@@ -1,4 +1,3 @@
 # (PART) Appendix {-}
 
-# Reference
-
+# References

--- a/submission-environment.Rmd
+++ b/submission-environment.Rmd
@@ -1,11 +1,11 @@
 # Running environment {#running-environment}
 
-In the previous chapter, we have generated instructions to manually
+In the previous chapter, we generated instructions to manually
 create the running environments for reproducing the A&R deliverables.
 
 In this chapter, we will focus on automating the creation of
-the R environments with R code, to accelerate the dry run testing process,
-simplify the ADRG instructions, and make it easy to recreate
+the R environments with R code to accelerate the dry run testing process,
+simplifying the ADRG instructions, and making it easy to recreate
 different environment settings with reproducible analysis results.
 
 ## Prerequisites
@@ -108,7 +108,7 @@ Note that to ensure better reproducibility, one should still use
 shift as time goes by.
 
 The helper functions `version_*()` and `snapshot_*()` could assist you
-to determine specific versions of R and Rtools that are currently available,
+in determining specific versions of R and Rtools that are currently available,
 besides generating and verifying the snapshot repo links.
 
 ## Update ADRG
@@ -144,7 +144,7 @@ cleanslate::use_cleanslate(
 
 Go to the working directory created above, double click the .Rproj file
 to open the project in RStudio. Follow the instructions to select the
-project-specific R version then restart RStudio. If successful,
+project-specific R version, then restart RStudio. If successful,
 the R version and package repo should be printed as defined above.
 
 3. Install open-source R packages

--- a/submission-overview.Rmd
+++ b/submission-overview.Rmd
@@ -1,6 +1,6 @@
 # (PART) eCTD submission {-}
 
-# Overview
+# Overview {#submission-overview}
 
 The electronic Common Technical Document (eCTD) is a standard format for
 the electronic submission of applications, amendments, supplements,
@@ -30,10 +30,10 @@ analyses were created and to confirm the analysis algorithms**.
 Sponsors should submit software programs in **ASCII text format**;
 however, executable file extensions should not be used."
 
-In Chapter \@ref(submission-package), we will focus on the approach
-to prepare proprietary R packages and analysis code into proper
+Chapter \@ref(submission-package) will focus on preparing
+proprietary R packages and analysis code into proper
 formats for submission.
 
-In Chapter \@ref(running-environment), we will discuss
+Chapter \@ref(running-environment) will discuss
 the recommendations to make the R code running environment
 reproducible for dry run tests and reviews.

--- a/submission-package.Rmd
+++ b/submission-package.Rmd
@@ -5,7 +5,8 @@ assets in the eCTD submission package we should focus on when
 submitting R code.
 Secondly, we will discuss how to prepare the proprietary R packages
 (if any), and make them part of the submission package.
-Lastly, we will provide reusable templates for updating ADaM Reviewer's Guide (ADRG) and Analysis Results Metadata (ARM),
+Lastly, we will provide reusable templates for updating
+ADaM Reviewer's Guide (ADRG) and Analysis Results Metadata (ARM)
 so that the reviewers receive proper instructions to reproduce the
 analysis results.
 
@@ -18,7 +19,8 @@ into text files and back.
 install.packages("pkglite")
 ```
 
-The demo project (R package) we will prepare for submission is called [`esubdemo`](https://github.com/elong0527/esubdemo) available on GitHub.
+The demo project (R package) we will prepare for submission is called
+[`esubdemo`](https://github.com/elong0527/esubdemo), available on GitHub.
 You can download or clone it:
 
 ```bash
@@ -37,7 +39,7 @@ We will assume the paths to the two folders are `esubdemo/` and `ectddemo/` belo
 
 ## The whole game
 
-In eCTD deliverable, the analysis dataset and source code are saved 
+In eCTD deliverable, the analysis dataset and source code are saved
 under the eCTD module 5 (clinical study reports) folder
 
 ```
@@ -102,7 +104,7 @@ This can be verified by `pkglite::verify_ascii()`
 - Any `.docx` files should be converted to PDF files for formal submission.
 
 Now you have a general idea about the relevant components of the
-submission package. 
+submission package.
 We will start preparing the proprietary R packages in the following sections.
 
 ## Practical considerations for R package submissions
@@ -129,7 +131,7 @@ recommended to submit them as part of the submission package.
 
 ### Dependency locations
 
-R package dependencies is another major factor to consider
+R package dependency is another major factor to consider
 before preparing your proprietary R package for submission.
 
 For dependencies available from CRAN or public Git repositories,
@@ -166,14 +168,14 @@ especially when involving compiled code (e.g., C, C++, Fortran).
 
 ## Prepare R Packages for submission
 
-To prepare R packages for submission, one needs to pack the packages into text files, and then verify if the file only contains ASSCII characters.
+To prepare R packages for submission, one needs to pack the packages into text files, and then verify if the file only contains ASCII characters.
 With packed packages, one can unpack and install them from the text file, too.
 
 ### Pack
 
 Let's pack the `esubdemo` package into a text file.
-Assume the source package path is `esubdemo/`,
-you should be able to pack the package with a single pipe:
+Assume the source package path is `esubdemo/`.
+You should be able to pack the package with a single pipe:
 
 ```{r, eval=FALSE}
 library("pkglite")
@@ -200,7 +202,7 @@ knitr::include_graphics("images/preview-txt.png")
 What happened in the pipe?
 The function `pkglite::collate()` evaluates a specified scope of
 folders and files defined by a list of **file specifications**,
-and generate a **file collection** object.
+and generates a **file collection** object.
 This file collection contains the metadata required to properly convert
 the files into text which is then used by `pkglite::pack()`.
 With this flow, you can define the scope of the R source package

--- a/tlf-ae-spec.Rmd
+++ b/tlf-ae-spec.Rmd
@@ -18,7 +18,7 @@ information in a study.
 knitr::include_graphics("tlf/tlf_spec_ae.pdf")
 ```
 
-The data used to summarize AE information is in `adsl` and `adae` datasets. 
+The data used to summarize AE information is in `adsl` and `adae` datasets.
 
 ```{r}
 adsl <- read_sas("adam_data/adsl.sas7bdat")
@@ -30,14 +30,14 @@ table. The percentage of participants for each AE criteria can be
 calculated as in Chapter \@ref(aesummary).
 
 In this way, let's focus on the analysis script for two advanced
-features for table layout.
+features for a table layout.
 
--   group content: AE can be summarized in multiple nested layers. (e.g.
-    by system organ class (SOC, `AESOC`) and specific AE term
-    (`AEDECOD`))
--   pagenization: there are many AE terms that can not be covered in one
-    page. Column headers and SOC information need to be repeated on
-    every page.
+- group content: AE can be summarized in multiple nested layers.
+  (e.g., by system organ class (SOC, `AESOC`) and specific AE term
+  (`AEDECOD`))
+- pagenization: there are many AE terms that can not be covered in one
+  page. Column headers and SOC information need to be repeated on
+  every page.
 
 In the code below, we count the number of subjects in each AE term by
 SOC and treatment group, and we create a new variable `order` and set it
@@ -133,7 +133,7 @@ group header. If a group of information is broken into multiple pages,
 the group header row is repeated on each page by default.
 
 We can also customize the text format by providing a matrix that has the
-same dimension as the input dataset (i.e. `tbl_ae_spec`). In the code
+same dimension as the input dataset (i.e., `tbl_ae_spec`). In the code
 below, we illustrate how to display **bold** text for group headers to
 highlight the nested structure of the table layout.
 
@@ -146,8 +146,8 @@ id <- ifelse(is.na(id), FALSE, id)
 text_format <- ifelse(id, "b", "")
 ```
 
-More discussion on `page_by`, `group_by` and `subline_by` 
-features can be found in the 
+More discussion on `page_by`, `group_by` and `subline_by`
+features can be found in the
 [`r2rtf` package website](https://merck.github.io/r2rtf/articles/example-sublineby-pageby-groupby.html.
 
 ```{r}

--- a/tlf-ae-summary.Rmd
+++ b/tlf-ae-summary.Rmd
@@ -1,6 +1,6 @@
 # AE summary {#aesummary}
 
-Following [ICH E3 guidance](https://database.ich.org/sites/default/files/E3_Guideline.pdf), 
+Following [ICH E3 guidance](https://database.ich.org/sites/default/files/E3_Guideline.pdf),
 we need to summarize which participants were included in each efficacy analysis in Section 12.2, Adverse Events (AEs).
 
 ```{r}
@@ -160,10 +160,10 @@ tbl_ae_summary %>%
 knitr::include_graphics("tlf/tlf_ae_summary.pdf")
 ```
 
-The procedure to generate a AE summary table can be summarized as follow：
+The procedure to generate an AE summary table can be summarized as follow:
 
 - Step 1: Read data into R, i.e., `adae` and `adsl`.
 - Step 2: Summarize participants in population by treatment group, and we name the dataset as `t_pop`.
-- Step 3: Summarize participants in population by required AE criteria of interest, 
+- Step 3: Summarize participants in population by required AE criteria of interest,
   and we name the dataset as `t_ae`.
 - Step 4: Rowly bind `t_pop` and `t_ae` and format it by `r2rtf`.

--- a/tlf-baseline.Rmd
+++ b/tlf-baseline.Rmd
@@ -4,15 +4,15 @@ Following [ICH E3 guidance](https://database.ich.org/sites/default/files/E3_Guid
 we need to summarize critical demographic and baseline characteristics of the patients
 in Section 11.2, Demographic and Other Baseline Characteristics.
 
-In this chapter, we illustrate how to create a simplified 
+In this chapter, we illustrate how to create a simplified
 baseline characteristics table in a study.
 
 ```{r, out.width = "100%", out.height = "400px", echo = FALSE, fig.align = "center"}
 knitr::include_graphics("tlf/tlf_base.pdf")
 ```
 
-There is many R packages that can efficiently summarize baseline information.
-The [`table1`](https://github.com/benjaminrich/table1) R package is one of them. 
+There are many R packages that can efficiently summarize baseline information.
+The [`table1`](https://github.com/benjaminrich/table1) R package is one of them.
 
 ```{r}
 library(table1)
@@ -24,8 +24,8 @@ library(stringr)
 library(tools)
 ```
 
-As in previous chapters, we first read `adsl` dataset that contain all 
-required information for baseline characteristics table. 
+As in previous chapters, we first read the `adsl` dataset that contains all
+the required information for the baseline characteristics table.
 
 ```{r}
 adsl <- read_sas("adam_data/adsl.sas7bdat")
@@ -49,10 +49,10 @@ tbl <- table1(~ SEX + AGE + RACE | TRT01P, data = ana)
 tbl
 ```
 
-The code below transfer the output into a dataframe 
-that only contain ASCII character 
-recommended by regulatory agencies. 
-`tbl_base` is used as input for `r2rtf` to create final report. 
+The code below transfer the output into a dataframe
+that only contain ASCII character
+recommended by regulatory agencies.
+`tbl_base` is used as input for `r2rtf` to create final report.
 
 ```{r}
 tbl_base <- tbl %>%
@@ -68,13 +68,13 @@ names(tbl_base) <- str_replace_all(names(tbl_base), intToUtf8(160), " ")
 tbl_base
 ```
 
-We start to define the format of the output. We highlight items that 
+We start to define the format of the output. We highlight items that
 are not discussed in previous discussion.
 
 `text_indent_first` and `test_indent_left` are used to control the indent
-space of text. They are helpful when you need to control the white space 
-of a long sentence. For example, "AMERICAN INDIAN OR ALASKA NATIVE" 
-in the table. 
+space of text. They are helpful when you need to control the white space
+of a long sentence. For example, "AMERICAN INDIAN OR ALASKA NATIVE"
+in the table.
 
 ```{r}
 colheader1 <- paste(names(tbl_base), collapse = "|")
@@ -111,5 +111,5 @@ In conclusion, the procedure to generate demographic and baseline characteristic
 
 - Step 1: Read the data set.
 - Step 2: Use `table1::table1()` to get the baseline characteristics table.
-- Step 3: Transfer the output in Step 2 into a data frame that only contains ASCII character.
-- Step 4: Define the format of the rtf table by using R package `r2rtf`.
+- Step 3: Transfer the output in Step 2 into a data frame that only contains ASCII characters.
+- Step 4: Define the format of the RTF table by using the R package `r2rtf`.

--- a/tlf-disposition.Rmd
+++ b/tlf-disposition.Rmd
@@ -1,11 +1,11 @@
 # Disposition {#disposition}
 
-Following [ICH E3 guidance](https://database.ich.org/sites/default/files/E3_Guideline.pdf), 
+Following [ICH E3 guidance](https://database.ich.org/sites/default/files/E3_Guideline.pdf),
 a summary needs to be provided to account for all participants who entered the study in Section 10.1, Disposition of Participants.
 
-The disposition of participant reports the numbers of participants who were randomized, 
-and who entered and completed each phase of the study. 
-In addition, the reasons for all post-randomization discontinuations, 
+The disposition of participant reports the numbers of participants who were randomized,
+and who entered and completed each phase of the study.
+In addition, the reasons for all post-randomization discontinuations,
 grouped by treatment and by major reason (lost to follow-up, adverse event, poor compliance, etc.).
 
 ```{r}
@@ -24,7 +24,7 @@ knitr::include_graphics("tlf/tbl_disp.pdf")
 The first step is to read in the relevant datasets into R.
 For a disposition table, all the required information is saved in a Subject-level Analysis Dataset (ADSL).
 The dataset is provided in `sas7bdat` format that is a SAS data format currently used in many clinical trial analysis and reporting.
-The `haven` package is able to read in the dataset, while maintaining its attributes (e.g. variable labels).
+The `haven` package is able to read in the dataset, while maintaining its attributes (e.g., variable labels).
 
 ```{r}
 adsl <- read_sas("adam_data/adsl.sas7bdat")
@@ -78,7 +78,7 @@ n_disc <- adsl %>%
 n_disc
 ```
 
-In the code below, we calculate the number and percentage of 
+In the code below, we calculate the number and percentage of
 participants who completed/discontinued the study for different reasons.
 
 ```{r}
@@ -124,8 +124,8 @@ n_reason <- n_reason %>%
 n_reason
 ```
 
-Now we combined individual rows into the whole table for reporting purpose. 
-`tbl_disp` is used as input for `r2rtf` to create final report. 
+Now we combined individual rows into the whole table for reporting purpose.
+`tbl_disp` is used as input for `r2rtf` to create final report.
 
 ```{r}
 tbl_disp <- bind_rows(n_rand, n_complete, n_disc, n_reason) %>%
@@ -134,7 +134,7 @@ tbl_disp <- bind_rows(n_rand, n_complete, n_disc, n_reason) %>%
 tbl_disp
 ```
 
-In the below code, formatting of the final table is defined. 
+In the below code, formatting of the final table is defined.
 Items that were not discussed in the previous sections, are highlighted below.
 
 The `rtf_title` defines table title.
@@ -174,11 +174,11 @@ knitr::include_graphics("tlf/tbl_disp.pdf")
 
 The procedure to generate a disposition table can be summarized as follows:
 
-- Step 1: Read subject level data into R, i.e. `adsl`.
+- Step 1: Read subject level data into R, i.e., `adsl`.
 - Step 2: Count participants in the analysis population and name the dataset `n_rand`.
 - Step 3: Count the number and percentage of participants that discontinued the study, and name the dataset `n_disc`.
-- Step 4: Count the number and percentage of participants that discontinued the study for different reasons, 
+- Step 4: Count the number and percentage of participants that discontinued the study for different reasons,
   and name the dataset `n_reason`.
 - Step 5: Count the number and percentage of participants that completed the study, and name the dataset `n_complete`.
-- Step 6: Bind `n_rand`, `n_disc`, `n_reason` and `n_complete` by row. 
+- Step 6: Bind `n_rand`, `n_disc`, `n_reason`, and `n_complete` by row.
 - Step 7: Write the final table to RTF

--- a/tlf-efficacy.Rmd
+++ b/tlf-efficacy.Rmd
@@ -1,8 +1,8 @@
 # Efficacy
 
 Following [ICH E3 guidance](https://database.ich.org/sites/default/files/E3_Guideline.pdf),
-we need to summarize primary and secondary efficacy endpoints,  
-in Section 11.4, Efficacy Results and Tabulations of Individual Participant. 
+we need to summarize primary and secondary efficacy endpoints,
+in Section 11.4, Efficacy Results and Tabulations of Individual Participant.
 
 ```{r}
 library(haven) # Read SAS data
@@ -12,7 +12,7 @@ library(r2rtf) # Reporting in RTF format
 library(emmeans) # LS mean estimation
 ```
 
-For efficacy analysis, we only analyze change from baseline glucose data at Week 24. 
+For efficacy analysis, we only analyze the change from baseline glucose data at week 24.
 
 ```{r, out.width = "100%", out.height = "400px", echo = FALSE, fig.align = "center"}
 knitr::include_graphics("tlf/tlf_eff.pdf")
@@ -20,7 +20,7 @@ knitr::include_graphics("tlf/tlf_eff.pdf")
 
 ## Analysis dataset
 
-To prepare analysis dataset, 
+To prepare the analysis dataset,
 we need both `adsl` and `adlbc` datasets for this analysis.
 
 ```{r}
@@ -28,11 +28,11 @@ adsl <- read_sas("adam_data/adsl.sas7bdat")
 adlb <- read_sas("adam_data/adlbc.sas7bdat")
 ```
 
-We first define the analysis dataset using 
-efficacy population flag `EFFFL` and 
+We first define the analysis dataset using
+efficacy population flag `EFFFL` and
 all records post baseline (`AVISITN > 1`) and on or before Week 24 (`AVISITN <= 24`).
-Here the variable `AVISITN` is the numerical analysis visit. 
-For example, if the analysis visit is recorded as "Baseline", i.e., `AVISIT = Baseline`, then `AVISITN = 0`; 
+Here the variable `AVISITN` is the numerical analysis visit.
+For example, if the analysis visit is recorded as "Baseline", i.e., `AVISIT = Baseline`, then `AVISITN = 0`;
 if the analysis visit is recorded as "Week 24", i.e., `AVISIT = Week 24`, then `AVISITN = 24`;
 if the analysis visit is blank, then `AVISITN` is also blank.
 We will discuss these missing values in Section 6.4.
@@ -51,7 +51,7 @@ ana <- gluc %>%
   mutate(AVISIT = factor(AVISIT, levels = unique(AVISIT)))
 ```
 
-Below is the first few records of the analysis dataset. 
+Below is the first few records of the analysis dataset.
 
 - AVAL: analysis value
 - BASE: baseline value
@@ -62,10 +62,11 @@ ana %>%
   select(USUBJID, TRTPN, AVISIT, AVAL, BASE, CHG) %>%
   head(4)
 ```
+
 ## Helper functions
 
-To prepare report dataframe, we created a few helper functions 
-by using the `fmt_num` function defined in Chapter \@ref(population). 
+To prepare the report data frame, we created a few helper functions
+by using the `fmt_num()` function defined in Chapter \@ref(population).
 
 - Format Estimators
 
@@ -144,17 +145,17 @@ t12
 
 ## Missing data imputation
 
-In clinical trials, missing data is inevitable. 
-In this study, there are also missing values in glucose data. 
+In clinical trials, missing data is inevitable.
+In this study, there are also missing values in glucose data.
 
 ```{r}
 count(ana, AVISIT)
 ```
 
-For simplicity and illustration purpose, 
+For simplicity and illustration purpose,
 we use the last observation carried forward (LOCF) approach to handle missing data.
-LOCF approach is a single imputation approach that is **not recommended** 
-in real studies. 
+LOCF approach is a single imputation approach that is **not recommended**
+in real studies.
 Interested readers can find more discussion on missing data approaches in the book:
 [The Prevention and Treatment of Missing Data in Clinical Trials](https://www.ncbi.nlm.nih.gov/books/NBK209904/pdf/Bookshelf_NBK209904.pdf).
 
@@ -165,16 +166,16 @@ ana_locf <- ana %>%
   filter(locf)
 ```
 
-## ANCOVA model 
+## ANCOVA model
 
-We start to analyze the imputed data using ANCOVA model with treatment and baseline glucose as covariates. 
+We start to analyze the imputed data using the ANCOVA model with treatment and baseline glucose as covariates.
 
 ```{r}
 fit <- lm(CHG ~ BASE + TRTP, data = ana_locf)
 summary(fit)
 ```
 
-Then we use the `emmeans` R package to obtain 
+Then we use the `emmeans` R package to obtain
 within and between group least square mean (LS mean)
 
 ```{r}
@@ -212,7 +213,7 @@ t2 <- fit_between %>%
 t2
 ```
 
-## Reporting 
+## Reporting
 
 We combine `t11`, `t12` and `t13` to get the first part of the report data
 
@@ -226,14 +227,14 @@ t1
 ```
 
 Then we use `r2rtf` to prepare the table format for `t1`.
-We also highlight how to handle special character in this example. 
+We also highlight how to handle special characters in this example.
 
-Special characters `^` and `_` are used to define superscript and subscript of text. And `{}` is to define the part that will be impacted. 
-For example, `{^a}` provide a superscript `a` for footnote notation.   
-`r2rtf` also support most LaTeX characters. 
-Examples can be found in
-[`r2rtf` Get Started Page](https://merck.github.io/r2rtf/articles/r2rtf.html#special-character). 
-The `text_convert` argument in `r2rtf_xxx` functions control whether convert special characters.
+Special characters `^` and `_` are used to define superscript and subscript of text. And `{}` is to define the part that will be impacted.
+For example, `{^a}` provide a superscript `a` for footnote notation.
+`r2rtf` also supports most LaTeX characters.
+Examples can be found on the
+[`r2rtf` get started page](https://merck.github.io/r2rtf/articles/r2rtf.html#special-character).
+The `text_convert` argument in `r2rtf_*()` functions controls whether convert special characters.
 
 ```{r}
 t1_rtf <- t1 %>%
@@ -296,7 +297,7 @@ knitr::include_graphics("tlf/tlf_eff2.pdf")
 
 Finally we combine the two parts to get the final table using `r2rtf`.
 This is achieved by providing a list of `t1_rtf` and `t2_rtf` as input for
-`rtf_encode`. 
+`rtf_encode`.
 
 ```{r}
 list(t1_rtf, t2_rtf) %>%
@@ -313,6 +314,6 @@ In conclusion, the procedure to generate the above efficacy results table is sum
 - Step 1: Read the data into R, i.e., `adsl` and `adlb`.
 - Step 2: Define the analysis dataset. In this example, we define two analysis datasets. The first dataset is the efficacy population (`gluc`). The second dataset is the collection of all records post baseline and on or before week 24 (`ana`).
 - Step 3: Impute the missing values. In our example, we name the `ana` dataset after imputation as `ana_locf`.
-- Step 4: Summarize `gluc`, i.e., calculate the mean and standard derivation, and then format it into a rtf table.
-- Step 5: Summarize `ana_locf`, i.e., calculate the pairwise comparison by ANCOVA model, and then format it into a rtf table.
+- Step 4: Summarize `gluc`, i.e., calculate the mean and standard derivation, and then format it into an RTF table.
+- Step 5: Summarize `ana_locf`, i.e., calculate the pairwise comparison by ANCOVA model, and then format it into an RTF table.
 - Step 6: Rowly bind the output in Step 4 and Step 5.

--- a/tlf-overview.Rmd
+++ b/tlf-overview.Rmd
@@ -1,93 +1,94 @@
 # (PART) Delivering TLFs in CSR {-}
 
-# Overview
+# Overview {#tlf-overview}
 
 ## Background
 
-In clinical trials, a critical step is
-submission to regulatory agencies. 
-[Electronic Common Technical Document (eCTD)](https://en.wikipedia.org/wiki/Electronic_common_technical_document) 
-has become a worldwide regulatory submission standard format. 
-For example, [the United States Food and Drug Administration (US FDA) required new drug applications, biologics license applications must be submitted using eCTD format](https://www.fda.gov/drugs/electronic-regulatory-submission-and-review/electronic-common-technical-document-ectd). Clinical Data Interchange Standards Consortium (CDISC) provided a 
+In clinical trials, a critical step is submission to regulatory agencies.
+[Electronic Common Technical Document (eCTD)](https://en.wikipedia.org/wiki/Electronic_common_technical_document)
+has become a worldwide regulatory submission standard format.
+For example, the United States Food and Drug Administration (US FDA) required
+new drug applications and biologics license applications
+[must be submitted using the eCTD format](https://www.fda.gov/drugs/electronic-regulatory-submission-and-review/electronic-common-technical-document-ectd).
+The Clinical Data Interchange Standards Consortium (CDISC) provided a
 [pilot project following ICH E3 guidance](https://bitbucket.cdisc.org/projects/CED/repos/sdtm-adam-pilot-project/browse).
 
-Within eCTD, clinical study reports (CSRs) are located at module 5. 
-[ICH E3 guidance](https://www.ich.org/page/efficacy-guidelines) provides 
-compilation of structure and content of clinical study reports.
+Within eCTD, clinical study reports (CSRs) are located at module 5.
+[ICH E3 guidance](https://www.ich.org/page/efficacy-guidelines) provides
+a compilation of the structure and content of clinical study reports.
 
 A typical CSR contains full details on the methods and results of an individual clinical study.
-In support of the statistical anlaysis, a large number of tables, listings and figures are
+In support of the statistical analysis, a large number of tables, listings, and figures are
 incorporated into the main text and appendices.
-In CDISC pilot project, an 
-[example CSR](https://bitbucket.cdisc.org/projects/CED/repos/sdtm-adam-pilot-project/browse/updated-pilot-submission-package/900172/m5/53-clin-stud-rep/535-rep-effic-safety-stud/5351-stud-rep-contr/cdiscpilot01/cdiscpilot01.pdf) 
-is also provided. If you are interested in more examples of clinical study reports, 
-the European Medicines Agency (EMA) publishes clinical data including 
-clinical study reports submitted by pharmaceutical companies 
-on [EMA clinical data website](https://clinicaldata.ema.europa.eu/web/cdp/home).  
+In the CDISC pilot project, an
+[example CSR](https://bitbucket.cdisc.org/projects/CED/repos/sdtm-adam-pilot-project/browse/updated-pilot-submission-package/900172/m5/53-clin-stud-rep/535-rep-effic-safety-stud/5351-stud-rep-contr/cdiscpilot01/cdiscpilot01.pdf)
+is also provided. If you are interested in more examples of clinical study reports,
+the European Medicines Agency (EMA) publishes clinical data, including
+clinical study reports submitted by pharmaceutical companies
+on the [EMA clinical data website](https://clinicaldata.ema.europa.eu/web/cdp/home).
 
-Building CSRs is a teamwork between clinicians, medical writers, statisticians, statistical programmers
-and other relevant specialists such as experts on biomarkers. 
-Here, we focus on the work and deliverables completed by statisticians and statistical programmers. 
-In an organization, they commonly work together to 
+Building CSRs is teamwork between clinicians, medical writers, statisticians, statistical programmers,
+and other relevant specialists such as experts on biomarkers.
+Here, we focus on the work and deliverables completed by statisticians and statistical programmers.
+In an organization, they commonly work together to
 define, develop, validate and deliver tables, listings, and figures (TLFs) required for a CSR to
 summarize the safety and/or safety of the pharmaceutical product.
-Microsoft Word is widely used to prepare CSR in the pharmaceutical industry. 
-Therefore, `rtf`, `doc`, `docx` are commonly used formats in their deliverables. 
+Microsoft Word is widely used to prepare CSR in the pharmaceutical industry.
+Therefore, `rtf`, `doc`, `docx` are commonly used formats in their deliverables.
 
 In this chapter, our focus is to illustrate how to create tables, listings, and figures (TLFs) in RTF format
-that is commonly used in a CSR. The examples are in compliance of 
-[FDA's Portable Document Format (PDF) Specifications](https://www.fda.gov/media/76797/download)
+that is commonly used in a CSR. The examples are in compliance with the
+[FDA's Portable Document Format (PDF) Specifications](https://www.fda.gov/media/76797/download).
 
-> FDA's PDF specification is a general reference, each organization can define 
-> more specific TLF format requirement that can be different from the examples in this book. 
+> FDA's PDF specification is a general reference. Each organization can define
+> more specific TLF format requirements that can be different from the examples in this book.
 
 ## Structure and content
 
-In the rest of this chapter, we are following the 
-[ICH E3 guidance](https://database.ich.org/sites/default/files/E3_Guideline.pdf) 
-on structure and content of clinical study reports. 
+In the rest of this chapter, we are following the
+[ICH E3 guidance](https://database.ich.org/sites/default/files/E3_Guideline.pdf)
+on the structure and content of clinical study reports.
 
-In a CSR, most of TLFs are located in 
+In a CSR, most of TLFs are located in
 
-- Section 10: Study participants 
+- Section 10: Study participants
 - Section 11: Efficacy evaluation
-- Section 12: Safety evaluation 
-- Section 14: Tables, listings and figures referrals but not included in the text
+- Section 12: Safety evaluation
+- Section 14: Tables, listings, and figures referrals but not included in the text
 - Section 16: Appendices
 
 ## Datasets
 
-We used publicly available CDISC pilot 
-[study data located at CDISC Bitbucket repository](https://bitbucket.cdisc.org/projects/CED/repos/sdtm-adam-pilot-project/browse/updated-pilot-submission-package/900172/m5/datasets/cdiscpilot01/analysis/adam/datasets).
+We used publicly available CDISC pilot
+[study data located in the CDISC Bitbucket repository](https://bitbucket.cdisc.org/projects/CED/repos/sdtm-adam-pilot-project/browse/updated-pilot-submission-package/900172/m5/datasets/cdiscpilot01/analysis/adam/datasets).
 
-For simplicity, we have downloaded all these datasets into `adam_data` folder of 
-this project and transfer them from `.xpt` format to `sas7bdat` format. 
+For simplicity, we have downloaded all these datasets into the `adam_data` folder of
+this project and converted them from the `.xpt` format to the `.sas7bdat` format.
 
-The dataset structure follows 
-[CDISC Analysis Data Model (ADaM)](https://www.cdisc.org/standards/foundational/adam). 
+The dataset structure follows
+[CDISC Analysis Data Model (ADaM)](https://www.cdisc.org/standards/foundational/adam).
 
+## Tools
 
-## Tools 
+In this part, we mainly use the R packages below to illustrate
+how to deliver TLFs in CSR.
 
-In this part, we mainly use the R packages below to illustrate 
-how to deliver TLFs in CSR. 
-
-- [tidyverse](https://www.tidyverse.org/): prepare datasets ready for reporting. 
+- [tidyverse](https://www.tidyverse.org/): prepare datasets ready for reporting.
 - [r2rtf](https://merck.github.io/r2rtf/): create RTF outputs
 
-### tidyverse 
+### tidyverse
 
-`tidyverse` is a collection of R packages to simplify the workflow to manipulate, 
-visualize and analyze data in R. 
-Those R packages share 
-[the tidy tools manifesto](https://cran.r-project.org/web/packages/tidyverse/vignettes/manifesto.html) 
+`tidyverse` is a collection of R packages to simplify the workflow to manipulate,
+visualize and analyze data in R.
+Those R packages share
+[the tidy tools manifesto](https://cran.r-project.org/web/packages/tidyverse/vignettes/manifesto.html)
 and are easy to use for interactive data analysis.
 
-RStudio provided outstanding [cheatsheets](https://www.rstudio.com/resources/cheatsheets/), 
+RStudio provided outstanding [cheatsheets](https://www.rstudio.com/resources/cheatsheets/)
 and [tutorials](https://github.com/rstudio-education/remaster-the-tidyverse) for `tidyverse`.
 
-There are also books to introduce tidyverse. 
-We assume reader to have experience in using `tidyverse` in this book.  
+There are also books to introduce tidyverse.
+We assume the reader to have experience in using `tidyverse` in this book.
 
 - [The tidyverse cookbook](https://rstudio-education.github.io/tidyverse-cookbook/)
 - [R for Data Science](https://r4ds.had.co.nz/)
@@ -95,37 +96,45 @@ We assume reader to have experience in using `tidyverse` in this book.
 ### r2rtf
 
 `r2rtf` is an R package to create production-ready tables and figures in RTF format.
-The R package is designed to 
+The R package is designed to
 
-- provide simple "verb" functions that correspond to each component of a table, 
-  to help you translate a data frame to a table in RTF file.
-- enable pipes (`%>%`). 
-- only focus on the **table format**. 
-  Data manipulation and analysis shall be handled by other R packages. (e.g. `tidyverse`)
+- provide simple "verb" functions that correspond to each component of a table,
+  to help you translate a data frame to a table in an RTF file;
+- enable pipes (`%>%`);
+- focus on the **table format** only.
+  Data manipulation and analysis shall be handled by other R packages (e.g., `tidyverse`).
 
-Before creating an RTF table we need to:
+Before creating an RTF table, we need to
 
-- Figure out table layout. 
-- Split the layout into small tasks in the form of a computer program.
-- Execute the program.
+- figure out the table layout;
+- split the layout into small tasks in the form of a computer program;
+- execute the program.
 
-We provided a brief introduction of `r2rtf` and show how to transfer 
+We provided a brief introduction of `r2rtf` and showed how to transfer
 data frames into Table, Listing, and Figures (TLFs).
 
-Other extended examples and features are covered in the 
-[`r2rtf` package website](https://merck.github.io/r2rtf/articles/index.html). 
+Other extended examples and features are covered on the
+[`r2rtf` package website](https://merck.github.io/r2rtf/articles/index.html).
 
-To explore the basic RTF generation verbs in `r2rtf`, 
-we'll use the dataset `r2rtf_adae` saved in the `r2rtf` package. 
+To explore the basic RTF generation verbs in `r2rtf`,
+we will use the dataset `r2rtf_adae` saved in the `r2rtf` package.
 This dataset contains adverse events (AE) information from a clinical trial.
 
-Below is the meaning of relevant variables. 
-More information can be found in the help page of the dataset (`?r2rtf_adae`)
+We will begin by loading the packages:
 
-In this example we consider three variables:
+```{r}
+library(dplyr) # Manipulate data
+library(tidyr) # Manipulate data
+library(r2rtf) # Reporting in RTF format
+```
+
+Below is the meaning of relevant variables.
+More information can be found on the help page of the dataset (`?r2rtf_adae`)
+
+In this example, we consider three variables:
 
 - USUBJID: Unique Subject Identifier
-- TRTA: Actual Treatment 
+- TRTA: Actual Treatment
 - AEDECOD: Dictionary-Derived Term
 
 ```{r}
@@ -134,9 +143,9 @@ r2rtf_adae %>%
   head(4)
 ```
 
-`dplyr` and `tidyr` packages within `tidyverse` are used 
-for data manipulation to create a data frame 
-that contains all the information we want to add in an RTF table. 
+`dplyr` and `tidyr` packages within `tidyverse` are used
+for data manipulation to create a data frame
+that contains all the information we want to add in an RTF table.
 
 ```{r}
 tbl <- r2rtf_adae %>%
@@ -151,22 +160,22 @@ Now we have a dataset `tbl` in preparing the final RTF table.
 `r2rtf` aims to provide one function for each type of table layout.
 Commonly used verbs include:
 
-- `rtf_page`: RTF page information
-- `rtf_title`: RTF title information
-- `rtf_colheader`: RTF column header information
-- `rtf_body`: RTF table body information
-- `rtf_footnote`: RTF footnote information
-- `rtf_source`: RTF data source information
+- `rtf_page()`: RTF page information
+- `rtf_title()`: RTF title information
+- `rtf_colheader()`: RTF column header information
+- `rtf_body()`: RTF table body information
+- `rtf_footnote()`: RTF footnote information
+- `rtf_source()`: RTF data source information
 
 All these verbs are designed to enable the usage of pipes (`%>%`).
-A full list of all functions can be found in the 
-[r2rtf package reference](https://merck.github.io/r2rtf/reference/index.html)
+A full list of all functions can be found in the
+[r2rtf package function reference manual](https://merck.github.io/r2rtf/reference/index.html).
 
 A minimal example below illustrates how to combine verbs using pipes to create an RTF table.
 
-- `rtf_body` is used to define table body layout. 
-- `rtf_encode` transfers table layout information into RTF syntax.
-- `write_rtf` save RTF encoding into a file with file extension `.rtf` 
+- `rtf_body()` is used to define table body layout.
+- `rtf_encode()` transfers table layout information into RTF syntax.
+- `write_rtf()` save RTF encoding into a file with file extension `.rtf`
 
 ```{r}
 head(tbl) %>%
@@ -179,20 +188,20 @@ head(tbl) %>%
 knitr::include_graphics("tlf/intro-ae1.pdf")
 ```
 
-If we want to adjust the width of each column to 
-provide more space to the first column, 
-this can be achieved by updating the `col_rel_width` argument 
-in the `rtf_body` function.
+If we want to adjust the width of each column to
+provide more space to the first column,
+this can be achieved by updating the `col_rel_width` argument
+in the `rtf_body()` function.
 
-In this example, the input of `col_rel_width` is a vector 
-with the same length for the number of columns. 
-This argument defines the relative width of each column 
-within a pre-defined total column width. 
+In this example, the input of `col_rel_width` is a vector
+with the same length for the number of columns.
+This argument defines the relative width of each column
+within a pre-defined total column width.
 
-In this example, the defined relative width is `3:2:2:2`. 
-Only the ratio of `col_rel_width` is used. 
-Therefore it is equivalent to use `col_rel_width = c(6,4,4,4)` 
-or `col_rel_width = c(1.5,1,1,1)`. 
+In this example, the defined relative width is `3:2:2:2`.
+Only the ratio of `col_rel_width` is used.
+Therefore it is equivalent to use `col_rel_width = c(6, 4, 4, 4)`
+or `col_rel_width = c(1.5, 1, 1, 1)`.
 
 ```{r}
 head(tbl) %>%
@@ -206,14 +215,14 @@ head(tbl) %>%
 knitr::include_graphics("tlf/intro-ae2.pdf")
 ```
 
-In the previous example, we found the issue of a misaligned column header. 
-We can fix the issue by using the `rtf_colheader` function.
+In the previous example, we found the issue of a misaligned column header.
+We can fix the issue by using the `rtf_colheader()` function.
 
-In `rtf_colheader`, `colheader` argument is used to provide the content of the column header. 
-We use `"|"` to separate the columns. 
+In `rtf_colheader()`, the `colheader` argument is used to provide the content of the column header.
+We use `"|"` to separate the columns.
 
 In the example below, `"Adverse Events | Placebo | Xanomeline High Dose | Xanomeline Low Dose"`
-define a column header with 4 columns. 
+define a column header with 4 columns.
 
 ```{r}
 head(tbl) %>%
@@ -230,13 +239,13 @@ head(tbl) %>%
 knitr::include_graphics("tlf/intro-ae3.pdf")
 ```
 
-In `rtf_*` functions such as `rtf_body`, `rtf_footnote`, 
-`text_justification` argument is used to align text. 
-Default is `"c"` for center justification. 
+In `rtf_*()` functions such as `rtf_body()`, `rtf_footnote()`,
+the `text_justification` argument is used to align text.
+Default is `"c"` for center justification.
 To vary text justification by column, use character vector with length of vector equal to
-number of columns displayed (e.g., `c("c","l","r")`). 
+number of columns displayed (e.g., `c("c", "l", "r")`).
 
-All possible inputs can be found in the table below. 
+All possible inputs can be found in the table below.
 
 ```{r}
 r2rtf:::justification()
@@ -255,16 +264,16 @@ head(tbl) %>%
 knitr::include_graphics("tlf/intro-ae5.pdf")
 ```
 
-In `rtf_*` functions such as `rtf_body`, `rtf_footnote`, etc.,
-`border_left`, `border_right`, `border_top`, and `border_bottom` control cell borders. 
+In `rtf_*()` functions such as `rtf_body()`, `rtf_footnote()`, etc.,
+`border_left`, `border_right`, `border_top`, and `border_bottom` control cell borders.
 
-If we want to remove the top border of `"Adverse Events"` in the header, 
-we can change the default value `"single"` to `""` in the `border_top` argument as showed below. 
+If we want to remove the top border of `"Adverse Events"` in the header,
+we can change the default value `"single"` to `""` in the `border_top` argument, as shown below.
 
-`r2rtf` support 26 different border types. The details can be found on 
+`r2rtf` support 26 different border types. The details can be found on
 the [r2rtf package website](https://merck.github.io/r2rtf/articles/rtf-row.html#border-type).
 
-In this example, we also demonstrate the possibility to add multiple column headers. 
+In this example, we also demonstrate the possibility of adding multiple column headers.
 
 ```{r}
 head(tbl) %>%
@@ -286,7 +295,7 @@ head(tbl) %>%
 knitr::include_graphics("tlf/intro-ae7.pdf")
 ```
 
-In the `r2rtf` R package [get started](https://merck.github.io/r2rtf/articles/r2rtf.html) page
+In the `r2rtf` R package [get started](https://merck.github.io/r2rtf/articles/r2rtf.html) page,
 there are more examples to illustrate how to customize
 
 - title, subtitle
@@ -294,9 +303,9 @@ there are more examples to illustrate how to customize
 - special character
 - etc.
 
-Those features will be introduced when we first use them in the rest of the chapters. 
+Those features will be introduced when we first use them in the rest of the chapters.
 
 There are other R packages that can create TLFs in `.rtf` or `.docx` format.
-Interested readers can refer "Microsoft/LibreOffice Formats" section in 
+Interested readers can refer "Microsoft/LibreOffice Formats" section in
 [CRAN Task View: Reproducible Research](https://cran.r-project.org/web/views/ReproducibleResearch.html)
-for an overview. 
+for an overview.

--- a/tlf-population.Rmd
+++ b/tlf-population.Rmd
@@ -13,7 +13,7 @@ library(r2rtf) # Reporting in RTF format
 ```
 
 In this chapter, we illustrate how to create a summary table for
-analysis population in a study.
+the analysis population in a study.
 
 ```{r, out.width = "100%", out.height = "400px", echo = FALSE, fig.align = "center"}
 knitr::include_graphics("tlf/tbl_pop.pdf")
@@ -43,7 +43,7 @@ adsl %>%
 
 ## Helper functions
 
-Before we write analysis code, let's discuss the possibility to reuse R
+Before we write the analysis code, let's discuss the possibility of reusing R
 code by writing some toy helper functions.
 
 As discussed in [R for data
@@ -51,7 +51,7 @@ science](https://r4ds.had.co.nz/functions.html#when-should-you-write-a-function)
 "You should consider writing a function whenever you've copied and
 pasted a block of code more than twice".
 
-In Chapter \@ref(disposition), there are few repeating steps to:
+In Chapter \@ref(disposition), there are a few repeating steps to:
 
 -   Format the percentages using the `formatC()` function.
 -   Calculate the numbers and percentages by groups.
@@ -89,7 +89,7 @@ fmt_num(n / n() * 100, digits = 1)
 ```
 
 To calculate the numbers and percentages of participants by groups, we
-provide a simple (but not robust) wrapper function, `count_by()` using
+provide a simple (but not robust) wrapper function, `count_by()`, using
 the `dplyr` and `tidyr` package.
 
 The function can be enhanced in multiple ways, but here we only focus on
@@ -215,6 +215,6 @@ as follow:
 
 - Step 1: Read data into R, i.e., `adsl`.
 - Step 2: Bind the counts/percentages of the ITT population, the
-  efficacy population and the safety population by row using the
+  efficacy population, and the safety population by row using the
   `count_by()` function.
 - Step 3: Format the output in Step 2 by `r2rtf`.


### PR DESCRIPTION
This PR fixes these details in all chapters:

- grammar and spelling
- trailing spaces
- duplicated overview chapter names
- get function names auto-linked in TLF overview chapter