### PR TITLE
automate rtf to pdf conversion

### DIFF
--- a/.github/workflows/bookdown.yaml
+++ b/.github/workflows/bookdown.yaml
@@ -17,6 +17,9 @@ jobs:
           echo ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula select true | sudo debconf-set-selections
           sudo apt-get install ttf-mscorefonts-installer
 
+      - name: Install LibreOffice
+        run: sudo apt-get install libreoffice --no-install-recommends
+
       - uses: actions/checkout@v2
 
       - uses: r-lib/actions/setup-pandoc@v1

--- a/common.R
+++ b/common.R
@@ -1,0 +1,7 @@
+rtf2pdf <- function(input) {
+  input <- normalizePath(input)
+  x <- "export LD_LIBRARY_PATH=:/usr/lib/libreoffice/program:/usr/lib/x86_64-linux-gnu/"
+  y <- paste0("libreoffice --invisible --headless --nologo --convert-to pdf --outdir tlf/ ", input)
+  z <- paste(x, y, sep = " && ")
+  if (Sys.getenv("GITHUB_ACTIONS") != "") system(z) else invisible(NULL)
+}

--- a/index.Rmd
+++ b/index.Rmd
@@ -30,8 +30,6 @@ library(pkglite)
 ```{r setup, include=FALSE}
 knitr::opts_chunk$set(comment = "#>", echo = TRUE, message = FALSE)
 options(dplyr.summarise.inform = FALSE)
-file.copy("static/CNAME", "_book", overwrite = TRUE)
-fs::dir_copy("slides/", "_book/slides", overwrite = TRUE)
 ```
 
 ```{r, eval = FALSE, include=FALSE}
@@ -39,6 +37,10 @@ r2rtf:::rtf_convert_format(
   list.files("tlf", pattern = ".rtf", full.names = TRUE),
   output_dir = "tlf"
 )
+```
+
+```{r, include=FALSE}
+source("common.R")
 ```
 
 ```{r, eval = FALSE, include=FALSE}

--- a/post-processing.R
+++ b/post-processing.R
@@ -1,0 +1,3 @@
+fs::dir_copy("tlf/", "_book/tlf", overwrite = TRUE)
+fs::dir_copy("slides/", "_book/slides", overwrite = TRUE)
+file.copy("static/CNAME", "_book", overwrite = TRUE)

--- a/references.Rmd
+++ b/references.Rmd
@@ -1,3 +1,7 @@
 # (PART) Appendix {-}
 
 # References {-}
+
+```{r, include=FALSE}
+source("post-processing.R")
+```

--- a/tlf-ae-spec.Rmd
+++ b/tlf-ae-spec.Rmd
@@ -171,6 +171,10 @@ tbl_ae_spec %>%
   write_rtf("tlf/tlf_spec_ae.rtf")
 ```
 
+```{r, include=FALSE}
+rtf2pdf("tlf/tlf_spec_ae.rtf")
+```
+
 ```{r, out.width = "100%", out.height = "400px", echo = FALSE, fig.align = "center"}
 knitr::include_graphics("tlf/tlf_spec_ae.pdf")
 ```

--- a/tlf-ae-summary.Rmd
+++ b/tlf-ae-summary.Rmd
@@ -156,6 +156,10 @@ tbl_ae_summary %>%
   write_rtf("tlf/tlf_ae_summary.rtf")
 ```
 
+```{r, include=FALSE}
+rtf2pdf("tlf/tlf_ae_summary.rtf")
+```
+
 ```{r, out.width = "100%", out.height = "400px", echo = FALSE, fig.align = "center"}
 knitr::include_graphics("tlf/tlf_ae_summary.pdf")
 ```

--- a/tlf-baseline.Rmd
+++ b/tlf-baseline.Rmd
@@ -103,6 +103,10 @@ tbl_base[-1, ] %>%
   write_rtf("tlf/tlf_base.rtf")
 ```
 
+```{r, include=FALSE}
+rtf2pdf("tlf/tlf_base.rtf")
+```
+
 ```{r, out.width = "100%", out.height = "400px", echo = FALSE, fig.align = "center"}
 knitr::include_graphics("tlf/tlf_base.pdf")
 ```

--- a/tlf-disposition.Rmd
+++ b/tlf-disposition.Rmd
@@ -168,6 +168,10 @@ tbl_disp %>%
   write_rtf("tlf/tbl_disp.rtf")
 ```
 
+```{r, include=FALSE}
+rtf2pdf("tlf/tbl_disp.rtf")
+```
+
 ```{r, out.width = "100%", out.height = "400px", echo = FALSE, fig.align = "center"}
 knitr::include_graphics("tlf/tbl_disp.pdf")
 ```

--- a/tlf-efficacy-ancova.Rmd
+++ b/tlf-efficacy-ancova.Rmd
@@ -270,6 +270,10 @@ t1_rtf %>%
   write_rtf("tlf/tlf_eff1.rtf")
 ```
 
+```{r, include=FALSE}
+rtf2pdf("tlf/tlf_eff1.rtf")
+```
+
 ```{r, out.width = "100%", out.height = "400px", echo = FALSE, fig.align = "center"}
 knitr::include_graphics("tlf/tlf_eff1.pdf")
 ```
@@ -292,6 +296,10 @@ t2_rtf %>%
   write_rtf("tlf/tlf_eff2.rtf")
 ```
 
+```{r, include=FALSE}
+rtf2pdf("tlf/tlf_eff2.rtf")
+```
+
 ```{r, out.width = "100%", out.height = "400px", echo = FALSE, fig.align = "center"}
 knitr::include_graphics("tlf/tlf_eff2.pdf")
 ```
@@ -304,6 +312,10 @@ This is achieved by providing a list of `t1_rtf` and `t2_rtf` as input for
 list(t1_rtf, t2_rtf) %>%
   rtf_encode() %>%
   write_rtf("tlf/tlf_eff.rtf")
+```
+
+```{r, include=FALSE}
+rtf2pdf("tlf/tlf_eff.rtf")
 ```
 
 ```{r, out.width = "100%", out.height = "400px", echo = FALSE, fig.align = "center"}

--- a/tlf-efficacy-km.Rmd
+++ b/tlf-efficacy-km.Rmd
@@ -104,6 +104,10 @@ rtf_read_png("tlf/fig_km.png") %>% # Read PNG files from the file path
   write_rtf(file = "tlf/fig_km.rtf")
 ```
 
+```{r, include=FALSE}
+rtf2pdf("tlf/fig_km.rtf")
+```
+
 ```{r, out.width = "100%", out.height = "400px", echo = FALSE, fig.align = "center"}
 knitr::include_graphics("tlf/fig_km.pdf")
 ```

--- a/tlf-overview.Rmd
+++ b/tlf-overview.Rmd
@@ -192,6 +192,10 @@ head(tbl) %>%
   write_rtf("tlf/intro-ae1.rtf") # Step 3 Write to a .rtf file
 ```
 
+```{r, include=FALSE}
+rtf2pdf("tlf/intro-ae1.rtf")
+```
+
 ```{r, out.width = "100%", out.height = "400px", echo = FALSE, fig.align = "center"}
 knitr::include_graphics("tlf/intro-ae1.pdf")
 ```
@@ -219,6 +223,10 @@ head(tbl) %>%
   write_rtf("tlf/intro-ae2.rtf")
 ```
 
+```{r, include=FALSE}
+rtf2pdf("tlf/intro-ae2.rtf")
+```
+
 ```{r, out.width = "100%", out.height = "400px", echo = FALSE, fig.align = "center"}
 knitr::include_graphics("tlf/intro-ae2.pdf")
 ```
@@ -241,6 +249,10 @@ head(tbl) %>%
   rtf_body(col_rel_width = c(3, 2, 2, 2)) %>%
   rtf_encode() %>%
   write_rtf("tlf/intro-ae3.rtf")
+```
+
+```{r, include=FALSE}
+rtf2pdf("tlf/intro-ae3.rtf")
 ```
 
 ```{r, out.width = "100%", out.height = "400px", echo = FALSE, fig.align = "center"}
@@ -266,6 +278,10 @@ head(tbl) %>%
   rtf_body(text_justification = c("l", "c", "c", "c")) %>%
   rtf_encode() %>%
   write_rtf("tlf/intro-ae5.rtf")
+```
+
+```{r, include=FALSE}
+rtf2pdf("tlf/intro-ae5.rtf")
 ```
 
 ```{r, out.width = "100%", out.height = "400px", echo = FALSE, fig.align = "center"}
@@ -297,6 +313,10 @@ head(tbl) %>%
   rtf_body(col_rel_width = c(3, 2, 2, 2)) %>%
   rtf_encode() %>%
   write_rtf("tlf/intro-ae7.rtf")
+```
+
+```{r, include=FALSE}
+rtf2pdf("tlf/intro-ae7.rtf")
 ```
 
 ```{r, out.width = "100%", out.height = "400px", echo = FALSE, fig.align = "center"}

--- a/tlf-population.Rmd
+++ b/tlf-population.Rmd
@@ -206,6 +206,10 @@ tbl_pop %>%
   write_rtf("tlf/tbl_pop.rtf")
 ```
 
+```{r, include=FALSE}
+rtf2pdf("tlf/tbl_pop.rtf")
+```
+
 ```{r, out.width = "100%", out.height = "400px", echo = FALSE, fig.align = "center"}
 knitr::include_graphics("tlf/tbl_pop.pdf")
 ```


### PR DESCRIPTION
This PR automates RTF to PDF conversion, by doing the following things:

1. Updated GitHub Action to install `libreoffice`.
1. Created `common.R` following the convention in Hadley's books to place the "shared" R functions and context settings (`rtf2pdf()` for conversion in this case); sourced it in `index.Rmd`.
1. Added a new block with a `rtf2pdf()` call after each `write_rtf()` call.
1. Created `post-processing.R` to copy the`tlf/` folder into the `_book/` folder, moved a few inherently post-processing things there, too; sourced it in `references.Rmd`.

To verify this: after build, check the embedded pdf in each chapter, now they should all be rendered with Times New Roman instead of Liberation Serif.