### PR TITLE
enable style.css to fix cover image issue

### DIFF
--- a/_output.yml
+++ b/_output.yml
@@ -4,5 +4,6 @@ bookdown::bs4_book:
     fg: "#0C2340"
     bg: "#ffffff"
   repo: https://github.com/elong0527/r4csr
+  css: style.css
   includes:
     in_header: [ga_script.html]

--- a/style.css
+++ b/style.css
@@ -1,14 +1,5 @@
-p.caption {
-  color: #00857C;
-  margin-top: 10px;
-}
-p code {
-  white-space: inherit;
-}
-pre {
-  word-break: normal;
-  word-wrap: normal;
-}
-pre code {
-  white-space: inherit;
+img.cover {
+  float: left;
+  margin: 0;
+  box-shadow: none;
 }


### PR DESCRIPTION
This PR fixes the cover image issue where it got 1 rem (16 px) of padding to the right box border by simply overwriting the CSS rules defined by `bs4_book()` with `style.css`.