### PR TITLE
update apt package index

### DIFF
--- a/.github/workflows/bookdown.yaml
+++ b/.github/workflows/bookdown.yaml
@@ -15,10 +15,10 @@ jobs:
       - name: Install ttf-mscorefonts-installer
         run: |
           echo ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula select true | sudo debconf-set-selections
-          sudo apt-get install ttf-mscorefonts-installer
+          sudo apt-get update && sudo apt-get install ttf-mscorefonts-installer
 
       - name: Install LibreOffice
-        run: sudo apt-get install libreoffice --no-install-recommends
+        run: sudo apt-get update && sudo apt-get install libreoffice --no-install-recommends
 
       - uses: actions/checkout@v2
 


### PR DESCRIPTION
It looks like we need to update the apt package index before installing stuff, libreoffice was just updated there today and the package index is outdated thus the 404 error.