### PR TITLE
Add install and build guide to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,20 @@ The quality of this document relies on you.
 - Authors: contributed the majority of content to at least one chapter.
 - Contributors: contributed at least one commit to the source code.
 - [List of authors and contributors](https://r4csr.org/preface.html#authors-and-contributors)
+
+## Installing dependencies
+
+Install the R packages used by the book with:
+
+```r
+# install.packages("remotes")
+remotes::install_deps()
+```
+
+## Build the book
+
+In RStudio, press Cmd/Ctrl + Shift + B. Or run:
+
+```R
+bookdown::render_book("index.Rmd")
+```

--- a/preface.Rmd
+++ b/preface.Rmd
@@ -88,7 +88,7 @@ The quality of this document relies on you.
 
 ```{r, results = "asis", echo = FALSE, message = FALSE}
 contributors <- read.csv("contributors.csv", stringsAsFactors = FALSE, na.strings = "")
-contributors$desc <- with(contributors, ifelse(is.na(username), name, paste0(name, " (\\@", username, ")")))
+contributors$desc <- with(contributors, ifelse(is.na(username), trimws(name), paste0(trimws(name), " (\\@", trimws(username), ")")))
 cat("  We are grateful for all the improvements brought by these contributors (in chronological order): ", sep = "")
 cat(paste0(contributors$desc, collapse = ", "))
 cat(".\n")


### PR DESCRIPTION
This PR:

- Added dependency installation and book building guide derived from hadley/ggplot2-book to README.
- Fixed the rendering of contributors list by allowing less-strictly formatted CSV data.