### PR TITLE
Add events table

### DIFF
--- a/events.tsv
+++ b/events.tsv
@@ -1,0 +1,5 @@
+Venue	Type	Date	Materials
+R/Pharma Conference	Workshop	2021-10-28	[Slides](https://r4csr.org/slides/workshop-slides.html)
+China-R Conference	Talk	2021-11-20	[Slides](https://r4csr.org/slides/china-r.html)
+ASA Princeton-Trenton Chapter	Short course	2021-12-02	[Slides](https://r4csr.org/slides/workshop-slides.html)
+GWU Biostatistics Center	Talk	2022-01-21	[Slides](https://r4csr.org/slides/r4csr-gwu.html)

--- a/index.Rmd
+++ b/index.Rmd
@@ -62,6 +62,12 @@ how to submit it to regulatory agencies.
 
 **This is a work-in-progress draft.**
 
+## Events {-}
+
+```{r, echo=FALSE}
+knitr::kable(read.table("events.tsv", stringsAsFactors = FALSE, header = TRUE, sep = "\t"))
+```
+
 ## License {-}
 
 This book is licensed to you under [Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International License](https://creativecommons.org/licenses/by-nc-nd/4.0/).


### PR DESCRIPTION
This PR adds a table for previous presentations (talks, courses, workshops) with links to materials to the welcome page.