### PR TITLE
Avoid accessing snapshot

### DIFF
--- a/submission-package.Rmd
+++ b/submission-package.Rmd
@@ -419,8 +419,10 @@ df2 <- data.frame(
   stringsAsFactors = FALSE
 )
 
-x <- available.packages(contriburl = contrib.url("https://mran.microsoft.com/snapshot/2021-08-06/"))
-df2$version <- x[match(df2$package, x[, "Package"]), "Version"]
+# # Commented out as the snapshot availability is not guaranteed
+# x <- available.packages(contriburl = contrib.url("https://mran.microsoft.com/snapshot/2021-08-06/"))
+# df2$version <- x[match(df2$package, x[, "Package"]), "Version"]
+df2$version <- c("0.2.0", "2.4.3", "1.0.7", "1.1.3", "1.6.2-1", "0.3.0")
 
 names(df2) <- c(
   "Open-Source R Analysis Package",


### PR DESCRIPTION
This PR avoids accessing the snapshot repo to retrieve the R package version numbers on-the-fly when creating the table.

It seems the snapshot's availability is not guaranteed 100% of the time (not responsive both locally and on GitHub Actions in the previous two PRs).