### PR TITLE
Fix broken URLs reported by URL checker

### DIFF
--- a/preface.Rmd
+++ b/preface.Rmd
@@ -10,7 +10,7 @@ a consistent and well-defined folder structure is crucial in
 managing a clinical trial analysis and reporting (A&R) project.
 
 We recommend using the
-[R package folder structure](https://github.com/rstudio/cheatsheets/raw/master/package-development.pdf)
+[R package folder structure](https://github.com/rstudio/cheatsheets/blob/main/package-development.pdf)
 to organize all the A&R-related source code and documentation for a clinical trial A&R project.
 The R package folder structure is well defined and widely used in the R community through repositories (e.g., CRAN).
 

--- a/project-folder.Rmd
+++ b/project-folder.Rmd
@@ -20,7 +20,7 @@ git clone https://github.com/elong0527/esubdemo.git
 ```
 
 For R users, you already benefit from a well-defined and consistent folder structure.
-That is the [R package folder structure](https://github.com/rstudio/cheatsheets/raw/master/package-development.pdf).
+That is the [R package folder structure](https://github.com/rstudio/cheatsheets/blob/main/package-development.pdf).
 Every R package developer is required to follow the same convention to organize
 their R functions before the R package can be disseminated through the Comprehensive R Archive Network (CRAN).
 As a user, you can easily install and use those R packages after downloading from CRAN.
@@ -137,7 +137,7 @@ we illustrate how to achieve reproducibility for R and R package versions.
 
 ::: {.rmdnote data-latex=""}
 This is the same level of reproducibility in most SAS environments:
-<https://support.sas.com/techsup/pcn/altopsys.html>
+<https://support.sas.com/en/technical-support/services-policies.html#altos>
 :::
 
 ### R version
@@ -178,7 +178,7 @@ The snapshot date allows us to freeze the source code repository.
 snapshot <- "2021-08-06"
 
 # set up repository based on the snapshot date
-repos <- paste0("https://mran.microsoft.com/snapshot/", snapshot)
+repos <- paste0("https://mran.microsoft.com/snapshot/", snapshot, "/")
 
 # define repo URL for project-specific package installation
 options(repos = repos)
@@ -197,7 +197,7 @@ Below information will be displayed after a new R session is opened.
 
 ```
 Current project R package repository:
-    https://mran.microsoft.com/snapshot/2021-08-06
+    https://mran.microsoft.com/snapshot/2021-08-06/
 ```
 
 ::: {.rmdnote data-latex=""}

--- a/slides/china-r.Rmd
+++ b/slides/china-r.Rmd
@@ -43,7 +43,7 @@ data("r2rtf_adae")
 
 ## Clarification from FDA
 
-- [FDA: Statistical Software Clarifying Statement](https://www.fda.gov/files/about%20fda/published/Statistical-Software-Clarifying-Statement-PDF.pdf)
+- [FDA: Statistical Software Clarifying Statement](https://www.fda.gov/media/161196/download)
 
 "FDA does not require use of any specific software for statistical analyses, and statistical software
 is not explicitly discussed in Title 21 of the Code of Federal Regulations [e.g., in 21CFR part
@@ -69,7 +69,7 @@ however, executable file extensions should not be used."
 ## Philosophy
 
 We share the same philosophy described in
-[Section 1.1 of R Packages book](https://r-pkgs.org/intro.html#intro-phil) and quote here.
+[Section 1.1 of the R Packages book](https://r-pkgs.org/introduction.html#intro-phil) and quote here.
 
 - "Anything that can be automated, should be automated."
 - "Do as little as possible by hand. Do as much as possible with functions."
@@ -90,7 +90,7 @@ an experimental R package for analytical-based group sequential design under pro
 
 Bookdown: <https://keaven.github.io/gsd-deming/>
 
-Training: [December 6th, Deming Conference 2021](https://demingconference.org/programs/2021-program/)
+Training: [December 6th, Deming Conference 2021](https://demingconference.org/wp-content/uploads/2021/07/2021-Deming-Conference-Printed-Program-v1.0.pdf)
 
 ## Tools for reporting and submission
 
@@ -255,7 +255,7 @@ More details: <https://r4csr.org/manage.html>
 - Contact us for R developer or Methodology Research Positions:
   - Yilong Zhang: <https://elong0527.github.io/>
   - Nan Xiao: <https://nanx.me/>
-  - Keaven Anderson: <https://www.linkedin.com/in/keaven-anderson-09aa7538/>
+  - Keaven Anderson: <https://keaven.github.io/>
 
 - Multiple open positions (statisticians/programmers) in China, EU, and US
   - US: <https://jobs.merck.com/bards>

--- a/slides/china-r.html
+++ b/slides/china-r.html
@@ -215,7 +215,7 @@ slide:not(.current) .plotly.html-widget{
 </article></slide><slide class=""><hgroup><h2>Clarification from FDA</h2></hgroup><article  id="clarification-from-fda">
 
 <ul>
-<li><a href='https://www.fda.gov/files/about%20fda/published/Statistical-Software-Clarifying-Statement-PDF.pdf' title=''>FDA: Statistical Software Clarifying Statement</a></li>
+<li><a href='https://www.fda.gov/media/161196/download' title=''>FDA: Statistical Software Clarifying Statement</a></li>
 </ul>
 
 <p>&ldquo;FDA does not require use of any specific software for statistical analyses, and statistical software is not explicitly discussed in Title 21 of the Code of Federal Regulations [e.g., in 21CFR part 11]. However, the software package(s) used for statistical analyses should be fully documented in the submission, including version and build identification.&rdquo;</p>
@@ -232,7 +232,7 @@ slide:not(.current) .plotly.html-widget{
 
 </article></slide><slide class=""><hgroup><h2>Philosophy</h2></hgroup><article  id="philosophy">
 
-<p>We share the same philosophy described in <a href='https://r-pkgs.org/intro.html#intro-phil' title=''>Section 1.1 of R Packages book</a> and quote here.</p>
+<p>We share the same philosophy described in <a href='https://r-pkgs.org/introduction.html#intro-phil' title=''>Section 1.1 of the R Packages book</a> and quote here.</p>
 
 <ul>
 <li>&ldquo;Anything that can be automated, should be automated.&rdquo;</li>
@@ -256,7 +256,7 @@ slide:not(.current) .plotly.html-widget{
 
 <p>Bookdown: <a href='https://keaven.github.io/gsd-deming/' title=''>https://keaven.github.io/gsd-deming/</a></p>
 
-<p>Training: <a href='https://demingconference.org/programs/2021-program/' title=''>December 6th, Deming Conference 2021</a></p>
+<p>Training: <a href='https://demingconference.org/wp-content/uploads/2021/07/2021-Deming-Conference-Printed-Program-v1.0.pdf' title=''>December 6th, Deming Conference 2021</a></p>
 
 </article></slide><slide class=""><hgroup><h2>Tools for reporting and submission</h2></hgroup><article  id="tools-for-reporting-and-submission">
 
@@ -446,7 +446,7 @@ pack(
 <ul>
 <li>Yilong Zhang: <a href='https://elong0527.github.io/' title=''>https://elong0527.github.io/</a></li>
 <li>Nan Xiao: <a href='https://nanx.me/' title=''>https://nanx.me/</a></li>
-<li>Keaven Anderson: <a href='https://www.linkedin.com/in/keaven-anderson-09aa7538/' title=''>https://www.linkedin.com/in/keaven-anderson-09aa7538/</a></li>
+<li>Keaven Anderson: <a href='https://keaven.github.io/' title=''>https://keaven.github.io/</a></li>
 </ul></li>
 <li>Multiple open positions (statisticians/programmers) in China, EU, and US
 

--- a/slides/fda-workshop-slides.Rmd
+++ b/slides/fda-workshop-slides.Rmd
@@ -138,7 +138,7 @@ In this workshop, we have three parts:
 - [Contributors](https://r4csr.org/preface.html#authors-and-contributors) of the training materials.
   - Please consider submitting issues or PR in the [github repo](https://github.com/elong0527/r4csr).
 
-- [R Consortium](https://www.r-consortium.org/projects/isc-working-groups)
+- [R Consortium](https://www.r-consortium.org/all-projects/isc-working-groups)
   - R validation hub
   - Submission working group
   - R Tables for Regulatory Submission (RTRS) working group
@@ -199,7 +199,7 @@ As an organization, we need to ensure compliance and reduce the risk of using R 
 ## Philosophy
 
 We share the same philosophy described in
-[Section 1.1 of R Packages book](https://r-pkgs.org/intro.html#intro-phil) and quote here.
+[Section 1.1 of the R Packages book](https://r-pkgs.org/introduction.html#intro-phil) and quote here.
 
 - "Anything that can be automated, should be automated."
 - "Do as little as possible by hand. Do as much as possible with functions."
@@ -328,7 +328,7 @@ knitr::include_graphics("function-summary.png")
 
 ## Efficacy Table
 
-<https://r4csr.org/efficacy.html>
+<https://r4csr.org/efficacy-table.html>
 
 ## AE Summary Table
 
@@ -388,7 +388,7 @@ project, with 4 goals in mind:
 
 ## Clarification from FDA
 
-- [FDA: Statistical Software Clarifying Statement](https://www.fda.gov/files/about%20fda/published/Statistical-Software-Clarifying-Statement-PDF.pdf)
+- [FDA: Statistical Software Clarifying Statement](https://www.fda.gov/media/161196/download)
 
 > "FDA does not require use of any specific software for statistical analyses, and statistical software
 is not explicitly discussed in Title 21 of the Code of Federal Regulations [e.g., in 21CFR part

--- a/slides/fda-workshop-slides.html
+++ b/slides/fda-workshop-slides.html
@@ -3348,7 +3348,7 @@ slides > slide:not(.segue) > hgroup > h2 {
 <ul>
 <li>Please consider submitting issues or PR in the <a href='https://github.com/elong0527/r4csr' title=''>github repo</a>.</li>
 </ul></li>
-<li><a href='https://www.r-consortium.org/projects/isc-working-groups' title=''>R Consortium</a>
+<li><a href='https://www.r-consortium.org/all-projects/isc-working-groups' title=''>R Consortium</a>
 
 <ul>
 <li>R validation hub</li>
@@ -3430,7 +3430,7 @@ slides > slide:not(.segue) > hgroup > h2 {
 
 </article></slide><slide class=""><hgroup><h2>Philosophy</h2></hgroup><article  id="philosophy" class="smaller ">
 
-<p>We share the same philosophy described in <a href='https://r-pkgs.org/intro.html#intro-phil' title=''>Section 1.1 of R Packages book</a> and quote here.</p>
+<p>We share the same philosophy described in <a href='https://r-pkgs.org/introduction.html#intro-phil' title=''>Section 1.1 of the R Packages book</a> and quote here.</p>
 
 <ul>
 <li>&ldquo;Anything that can be automated, should be automated.&rdquo;</li>
@@ -3615,7 +3615,7 @@ slides > slide:not(.segue) > hgroup > h2 {
 
 </article></slide><slide class=""><hgroup><h2>Efficacy Table</h2></hgroup><article  id="efficacy-table" class="smaller ">
 
-<p><a href='https://r4csr.org/efficacy.html' title=''>https://r4csr.org/efficacy.html</a></p>
+<p><a href='https://r4csr.org/efficacy-table.html' title=''>https://r4csr.org/efficacy-table.html</a></p>
 
 </article></slide><slide class=""><hgroup><h2>AE Summary Table</h2></hgroup><article  id="ae-summary-table" class="smaller ">
 
@@ -3684,7 +3684,7 @@ slides > slide:not(.segue) > hgroup > h2 {
 </article></slide><slide class=""><hgroup><h2>Clarification from FDA</h2></hgroup><article  id="clarification-from-fda" class="smaller ">
 
 <ul>
-<li><a href='https://www.fda.gov/files/about%20fda/published/Statistical-Software-Clarifying-Statement-PDF.pdf' title=''>FDA: Statistical Software Clarifying Statement</a></li>
+<li><a href='https://www.fda.gov/media/161196/download' title=''>FDA: Statistical Software Clarifying Statement</a></li>
 </ul>
 
 <blockquote>

--- a/slides/r4csr-gwu.Rmd
+++ b/slides/r4csr-gwu.Rmd
@@ -31,7 +31,7 @@ data("r2rtf_adae")
 
 ## Clarification from FDA
 
-- [FDA: Statistical Software Clarifying Statement](https://www.fda.gov/files/about%20fda/published/Statistical-Software-Clarifying-Statement-PDF.pdf)
+- [FDA: Statistical Software Clarifying Statement](https://www.fda.gov/media/161196/download)
 
 > "FDA does not require use of any specific software for statistical analyses, and statistical software
 is not explicitly discussed in Title 21 of the Code of Federal Regulations [e.g., in 21CFR part
@@ -59,7 +59,7 @@ As an organization, we need to ensure compliance and reduce the risk of using R 
 
 - R is widely used in visualization
   - [SafetyGraphics](https://github.com/SafetyGraphics/safetyGraphics)
-  - [forestly](https://elong0527.github.io/forestly/articles/example.html#construct-interactive-forest-plot-1): [Interactive forest plot for DMC safety monitoring in clinical trials](https://rinpharma.com/publication/rinpharma_194/)
+  - [forestly](https://elong0527.github.io/forestly/articles/forestly.html): [Interactive forest plot for DMC safety monitoring in clinical trials](https://rinpharma.com/publication/rinpharma_206/)
 
 ## Background
 
@@ -155,7 +155,7 @@ sponsor shall enhance reproducibility.
 ## Philosophy
 
 We share the same philosophy described in
-[Section 1.1 of R Packages book](https://r-pkgs.org/intro.html#intro-phil) and quote here.
+[Section 1.1 of the R Packages book](https://r-pkgs.org/introduction.html#intro-phil) and quote here.
 
 - "Anything that can be automated, should be automated."
 - "Do as little as possible by hand. Do as much as possible with functions."

--- a/slides/r4csr-gwu.html
+++ b/slides/r4csr-gwu.html
@@ -193,7 +193,7 @@ slide:not(.current) .plotly.html-widget{
 </article></slide><slide class=""><hgroup><h2>Clarification from FDA</h2></hgroup><article  id="clarification-from-fda">
 
 <ul>
-<li><a href='https://www.fda.gov/files/about%20fda/published/Statistical-Software-Clarifying-Statement-PDF.pdf' title=''>FDA: Statistical Software Clarifying Statement</a></li>
+<li><a href='https://www.fda.gov/media/161196/download' title=''>FDA: Statistical Software Clarifying Statement</a></li>
 </ul>
 
 <blockquote>
@@ -228,7 +228,7 @@ slide:not(.current) .plotly.html-widget{
 
 <ul>
 <li><a href='https://github.com/SafetyGraphics/safetyGraphics' title=''>SafetyGraphics</a></li>
-<li><a href='https://elong0527.github.io/forestly/articles/example.html#construct-interactive-forest-plot-1' title=''>forestly</a>: <a href='https://rinpharma.com/publication/rinpharma_194/' title=''>Interactive forest plot for DMC safety monitoring in clinical trials</a></li>
+<li><a href='https://elong0527.github.io/forestly/articles/forestly.html' title=''>forestly</a>: <a href='https://rinpharma.com/publication/rinpharma_206/' title=''>Interactive forest plot for DMC safety monitoring in clinical trials</a></li>
 </ul></li>
 </ul>
 
@@ -345,7 +345,7 @@ slide:not(.current) .plotly.html-widget{
 
 </article></slide><slide class=""><hgroup><h2>Philosophy</h2></hgroup><article  id="philosophy">
 
-<p>We share the same philosophy described in <a href='https://r-pkgs.org/intro.html#intro-phil' title=''>Section 1.1 of R Packages book</a> and quote here.</p>
+<p>We share the same philosophy described in <a href='https://r-pkgs.org/introduction.html#intro-phil' title=''>Section 1.1 of the R Packages book</a> and quote here.</p>
 
 <ul>
 <li>&ldquo;Anything that can be automated, should be automated.&rdquo;</li>

--- a/slides/r4csr-psi.Rmd
+++ b/slides/r4csr-psi.Rmd
@@ -133,7 +133,7 @@ As an organization, we need to ensure compliance and reduce the risk of using R 
 
 - R is widely used in visualization
   - [metalite.table1](https://elong0527.github.io/metalite.table1/articles/metalite-table1.html): Interactive demographic table.
-  - [forestly](https://elong0527.github.io/forestly/articles/example.html#construct-interactive-forest-plot-1): [Interactive forest plot for DMC safety monitoring in clinical trials](https://rinpharma.com/publication/rinpharma_194/)
+  - [forestly](https://elong0527.github.io/forestly/articles/example.html#construct-interactive-forest-plot-1): [Interactive forest plot for DMC safety monitoring in clinical trials](https://rinpharma.com/publication/rinpharma_206/)
 
 ## Background
 
@@ -259,7 +259,7 @@ sponsor shall enhance reproducibility.
 ## Philosophy
 
 We share the same philosophy described in
-[Section 1.1 of R Packages book](https://r-pkgs.org/intro.html#intro-phil) and quote here.
+[Section 1.1 of the R Packages book](https://r-pkgs.org/introduction.html#intro-phil) and quote here.
 
 - "Anything that can be automated, should be automated."
 - "Do as little as possible by hand. Do as much as possible with functions."

--- a/slides/r4csr-psi.html
+++ b/slides/r4csr-psi.html
@@ -3337,7 +3337,7 @@ slides > slide:not(.segue) > hgroup > h2 {
 
 <ul>
 <li><a href='https://elong0527.github.io/metalite.table1/articles/metalite-table1.html' title=''>metalite.table1</a>: Interactive demographic table.</li>
-<li><a href='https://elong0527.github.io/forestly/articles/example.html#construct-interactive-forest-plot-1' title=''>forestly</a>: <a href='https://rinpharma.com/publication/rinpharma_194/' title=''>Interactive forest plot for DMC safety monitoring in clinical trials</a></li>
+<li><a href='https://elong0527.github.io/forestly/articles/example.html#construct-interactive-forest-plot-1' title=''>forestly</a>: <a href='https://rinpharma.com/publication/rinpharma_206/' title=''>Interactive forest plot for DMC safety monitoring in clinical trials</a></li>
 </ul></li>
 </ul>
 
@@ -3498,7 +3498,7 @@ slides > slide:not(.segue) > hgroup > h2 {
 
 </article></slide><slide class=""><hgroup><h2>Philosophy</h2></hgroup><article  id="philosophy" class="smaller ">
 
-<p>We share the same philosophy described in <a href='https://r-pkgs.org/intro.html#intro-phil' title=''>Section 1.1 of R Packages book</a> and quote here.</p>
+<p>We share the same philosophy described in <a href='https://r-pkgs.org/introduction.html#intro-phil' title=''>Section 1.1 of the R Packages book</a> and quote here.</p>
 
 <ul>
 <li>&ldquo;Anything that can be automated, should be automated.&rdquo;</li>

--- a/slides/r4csr-rstudio.Rmd
+++ b/slides/r4csr-rstudio.Rmd
@@ -135,7 +135,7 @@ As an organization, we need to ensure compliance and reduce the risk of using R 
 
 - R is widely used in visualization
   - [SafetyGraphics](https://github.com/SafetyGraphics/safetyGraphics)
-  - [forestly](https://elong0527.github.io/forestly/articles/example.html#construct-interactive-forest-plot-1): [Interactive forest plot for DMC safety monitoring in clinical trials](https://rinpharma.com/publication/rinpharma_194/)
+  - [forestly](https://elong0527.github.io/forestly/articles/example.html#construct-interactive-forest-plot-1): [Interactive forest plot for DMC safety monitoring in clinical trials](https://rinpharma.com/publication/rinpharma_206/)
 
 ## Background
 
@@ -249,7 +249,7 @@ sponsor shall enhance reproducibility.
 ## Philosophy
 
 We share the same philosophy described in
-[Section 1.1 of R Packages book](https://r-pkgs.org/intro.html#intro-phil) and quote here.
+[Section 1.1 of the R Packages book](https://r-pkgs.org/introduction.html#intro-phil) and quote here.
 
 - "Anything that can be automated, should be automated."
 - "Do as little as possible by hand. Do as much as possible with functions."

--- a/slides/r4csr-rstudio.html
+++ b/slides/r4csr-rstudio.html
@@ -3337,7 +3337,7 @@ slides > slide:not(.segue) > hgroup > h2 {
 
 <ul>
 <li><a href='https://github.com/SafetyGraphics/safetyGraphics' title=''>SafetyGraphics</a></li>
-<li><a href='https://elong0527.github.io/forestly/articles/example.html#construct-interactive-forest-plot-1' title=''>forestly</a>: <a href='https://rinpharma.com/publication/rinpharma_194/' title=''>Interactive forest plot for DMC safety monitoring in clinical trials</a></li>
+<li><a href='https://elong0527.github.io/forestly/articles/example.html#construct-interactive-forest-plot-1' title=''>forestly</a>: <a href='https://rinpharma.com/publication/rinpharma_206/' title=''>Interactive forest plot for DMC safety monitoring in clinical trials</a></li>
 </ul></li>
 </ul>
 
@@ -3482,7 +3482,7 @@ slides > slide:not(.segue) > hgroup > h2 {
 
 </article></slide><slide class=""><hgroup><h2>Philosophy</h2></hgroup><article  id="philosophy" class="smaller ">
 
-<p>We share the same philosophy described in <a href='https://r-pkgs.org/intro.html#intro-phil' title=''>Section 1.1 of R Packages book</a> and quote here.</p>
+<p>We share the same philosophy described in <a href='https://r-pkgs.org/introduction.html#intro-phil' title=''>Section 1.1 of the R Packages book</a> and quote here.</p>
 
 <ul>
 <li>&ldquo;Anything that can be automated, should be automated.&rdquo;</li>

--- a/slides/workshop-slides.Rmd
+++ b/slides/workshop-slides.Rmd
@@ -65,7 +65,7 @@ In this workshop, we have three parts:
 - [Contributors](https://r4csr.org/) of the training materials.
   - Please consider submitting issues or PR in the repo.
 
-- [R Consortium](https://www.r-consortium.org/projects/isc-working-groups)
+- [R Consortium](https://www.r-consortium.org/all-projects/isc-working-groups)
   - R validation hub
   - Submission working group
   - R Tables for Regulatory Submission (RTRS) working group
@@ -115,7 +115,7 @@ install.packages(c(
 ## Philosophy
 
 We share the same philosophy described in
-[Section 1.1 of R Packages book](https://r-pkgs.org/intro.html#intro-phil) and quote here.
+[Section 1.1 of the R Packages book](https://r-pkgs.org/introduction.html#intro-phil) and quote here.
 
 - "Anything that can be automated, should be automated."
 - "Do as little as possible by hand. Do as much as possible with functions."
@@ -138,7 +138,7 @@ In a CSR, most of TLFs are located in
 
 ## Datasets
 
-- Public available CDISC pilot [study data located at CDISC Bitbucket repository](https://bitbucket.cdisc.org/projects/CED/repos/sdtm-adam-pilot-project/browse/updated-pilot-submission-package/900172/m5/datasets/cdiscpilot01/analysis/adam/datasets).
+- Public available CDISC pilot [study data located at CDISC GitHub repository](https://github.com/cdisc-org/sdtm-adam-pilot-project/tree/master/updated-pilot-submission-package/900172/m5/datasets/cdiscpilot01/analysis/adam/datasets).
 
 - The dataset structure follows the [CDISC Analysis Data Model (ADaM)](https://www.cdisc.org/standards/foundational/adam).
 
@@ -252,7 +252,7 @@ knitr::include_graphics("function-summary.png")
 
 ## Efficacy table
 
-<https://r4csr.org/efficacy.html>
+<https://r4csr.org/efficacy-table.html>
 
 ## AE Summary table
 

--- a/slides/workshop-slides.html
+++ b/slides/workshop-slides.html
@@ -245,7 +245,7 @@ slide:not(.current) .plotly.html-widget{
 <ul>
 <li>Please consider submitting issues or PR in the repo.</li>
 </ul></li>
-<li><a href='https://www.r-consortium.org/projects/isc-working-groups' title=''>R Consortium</a>
+<li><a href='https://www.r-consortium.org/all-projects/isc-working-groups' title=''>R Consortium</a>
 
 <ul>
 <li>R validation hub</li>
@@ -309,7 +309,7 @@ slide:not(.current) .plotly.html-widget{
 
 </article></slide><slide class=""><hgroup><h2>Philosophy</h2></hgroup><article  id="philosophy">
 
-<p>We share the same philosophy described in <a href='https://r-pkgs.org/intro.html#intro-phil' title=''>Section 1.1 of R Packages book</a> and quote here.</p>
+<p>We share the same philosophy described in <a href='https://r-pkgs.org/introduction.html#intro-phil' title=''>Section 1.1 of the R Packages book</a> and quote here.</p>
 
 <ul>
 <li>&ldquo;Anything that can be automated, should be automated.&rdquo;</li>
@@ -336,7 +336,7 @@ slide:not(.current) .plotly.html-widget{
 </article></slide><slide class=""><hgroup><h2>Datasets</h2></hgroup><article  id="datasets">
 
 <ul>
-<li><p>Public available CDISC pilot <a href='https://bitbucket.cdisc.org/projects/CED/repos/sdtm-adam-pilot-project/browse/updated-pilot-submission-package/900172/m5/datasets/cdiscpilot01/analysis/adam/datasets' title=''>study data located at CDISC Bitbucket repository</a>.</p></li>
+<li><p>Public available CDISC pilot <a href='https://github.com/cdisc-org/sdtm-adam-pilot-project/tree/master/updated-pilot-submission-package/900172/m5/datasets/cdiscpilot01/analysis/adam/datasets' title=''>study data located at CDISC GitHub repository</a>.</p></li>
 <li><p>The dataset structure follows the <a href='https://www.cdisc.org/standards/foundational/adam' title=''>CDISC Analysis Data Model (ADaM)</a>.</p></li>
 <li><p>Source data: <a href='https://github.com/elong0527/r4csr/tree/master/data-adam' title=''>https://github.com/elong0527/r4csr/tree/master/data-adam</a></p></li>
 </ul>
@@ -503,7 +503,7 @@ slide:not(.current) .plotly.html-widget{
 
 </article></slide><slide class=""><hgroup><h2>Efficacy table</h2></hgroup><article  id="efficacy-table">
 
-<p><a href='https://r4csr.org/efficacy.html' title=''>https://r4csr.org/efficacy.html</a></p>
+<p><a href='https://r4csr.org/efficacy-table.html' title=''>https://r4csr.org/efficacy-table.html</a></p>
 
 </article></slide><slide class=""><hgroup><h2>AE Summary table</h2></hgroup><article  id="ae-summary-table">
 

--- a/tlf-overview.Rmd
+++ b/tlf-overview.Rmd
@@ -17,7 +17,7 @@ For example, the United States Food and Drug Administration (US FDA) requires
 new drug applications and biologics license applications
 [must be submitted using the eCTD format](https://www.fda.gov/drugs/electronic-regulatory-submission-and-review/electronic-common-technical-document-ectd).
 The Clinical Data Interchange Standards Consortium (CDISC) provides a
-[pilot project following ICH E3 guidance](https://bitbucket.cdisc.org/projects/CED/repos/sdtm-adam-pilot-project/browse).
+[pilot project following ICH E3 guidance](https://github.com/cdisc-org/sdtm-adam-pilot-project).
 
 Within eCTD, clinical study reports (CSRs) are located at module 5.
 [ICH E3 guidance](https://www.ich.org/page/efficacy-guidelines) provides
@@ -27,7 +27,7 @@ A typical CSR contains full details on the methods and results of an individual 
 In support of the statistical analysis, a large number of tables, listings, and figures are
 incorporated into the main text and appendices.
 In the CDISC pilot project, an
-[example CSR](https://bitbucket.cdisc.org/projects/CED/repos/sdtm-adam-pilot-project/browse/updated-pilot-submission-package/900172/m5/53-clin-stud-rep/535-rep-effic-safety-stud/5351-stud-rep-contr/cdiscpilot01/cdiscpilot01.pdf)
+[example CSR](https://github.com/cdisc-org/sdtm-adam-pilot-project/blob/master/updated-pilot-submission-package/900172/m5/53-clin-stud-rep/535-rep-effic-safety-stud/5351-stud-rep-contr/cdiscpilot01/cdiscpilot01.pdf)
 is also provided. If you are interested in more examples of clinical study reports,
 you can go to the [European Medicines Agency (EMA) clinical data website](https://clinicaldata.ema.europa.eu/web/cdp/home).
 
@@ -66,7 +66,7 @@ In a CSR, most of TLFs are located in
 ## Datasets
 
 We used publicly available CDISC pilot
-[study data located in the CDISC Bitbucket repository](https://bitbucket.cdisc.org/projects/CED/repos/sdtm-adam-pilot-project/browse/updated-pilot-submission-package/900172/m5/datasets/cdiscpilot01/analysis/adam/datasets).
+[study data located in the CDISC GitHub repository](https://github.com/cdisc-org/sdtm-adam-pilot-project/tree/master/updated-pilot-submission-package/900172/m5/datasets/cdiscpilot01/analysis/adam/datasets).
 
 For simplicity, we have downloaded all these datasets into the `data-adam/`
 folder of this project and converted them from the `.xpt` format to
@@ -95,10 +95,10 @@ Readers are encouraged to explore other R packages to find the proper tools to f
 tidyverse is a collection of R packages to simplify the workflow to manipulate,
 visualize and analyze data in R.
 Those R packages share
-[the tidy tools manifesto](https://cran.r-project.org/web/packages/tidyverse/vignettes/manifesto.html)
+[the tidy tools manifesto](https://tidyverse.tidyverse.org/articles/manifesto.html)
 and are easy to use for interactive data analysis.
 
-RStudio provided outstanding [cheatsheets](https://www.rstudio.com/resources/cheatsheets/)
+RStudio provided outstanding [cheatsheets](https://posit.co/resources/cheatsheets/)
 and [tutorials](https://github.com/rstudio-education/remaster-the-tidyverse) for tidyverse.
 
 There are also books to introduce tidyverse.


### PR DESCRIPTION
By running `check-url.R` in https://github.com/elong0527/r4csr/pull/96, I saw a list of URLs were broken for different reasons.

This PR fixes them all. Now running `check-url.R` again, I'm seeing

```
fetching [ 126 / 126 ]
✔ All URLs are correct!
```