### PR TITLE
Reset `-webkit-font-smoothing`

### DIFF
--- a/custom.scss
+++ b/custom.scss
@@ -7,3 +7,7 @@ $primary: #00857C !default;
 img.quarto-cover-image {
     box-shadow: 0 .5rem 1rem rgba(0, 0, 0, .15);
 }
+
+body {
+    -webkit-font-smoothing: auto;
+}


### PR DESCRIPTION
This PR fixes #109 by resetting the `-webkit-font-smoothing` CSS property.

This will make the rendered fonts look better on today's monitors in general.