### PR TITLE
Update or remove obsolete URLs

### DIFF
--- a/slides/fda-workshop-slides.Rmd
+++ b/slides/fda-workshop-slides.Rmd
@@ -194,7 +194,7 @@ As an organization, we need to ensure compliance and reduce the risk of using R 
 
 - R is widely used in visualization
   - [metalite.table1](https://elong0527.github.io/metalite.table1/articles/metalite-table1.html): Interactive demographic table.
-  - [forestly](https://elong0527.github.io/forestly/articles/forestly.html): Interactive forest plot for DMC safety monitoring in clinical trials
+  - [forestly](https://merck.github.io/forestly/articles/forestly.html): Interactive forest plot for DMC safety monitoring in clinical trials
 
 ## Philosophy
 

--- a/slides/fda-workshop-slides.html
+++ b/slides/fda-workshop-slides.html
@@ -3424,7 +3424,7 @@ slides > slide:not(.segue) > hgroup > h2 {
 
 <ul>
 <li><a href='https://elong0527.github.io/metalite.table1/articles/metalite-table1.html' title=''>metalite.table1</a>: Interactive demographic table.</li>
-<li><a href='https://elong0527.github.io/forestly/articles/forestly.html' title=''>forestly</a>: Interactive forest plot for DMC safety monitoring in clinical trials</li>
+<li><a href='https://merck.github.io/forestly/articles/forestly.html' title=''>forestly</a>: Interactive forest plot for DMC safety monitoring in clinical trials</li>
 </ul></li>
 </ul>
 

--- a/slides/r4csr-gwu.Rmd
+++ b/slides/r4csr-gwu.Rmd
@@ -59,7 +59,7 @@ As an organization, we need to ensure compliance and reduce the risk of using R 
 
 - R is widely used in visualization
   - [SafetyGraphics](https://github.com/SafetyGraphics/safetyGraphics)
-  - [forestly](https://elong0527.github.io/forestly/articles/forestly.html): [Interactive forest plot for DMC safety monitoring in clinical trials](https://rinpharma.com/publication/rinpharma_206/)
+  - [forestly](https://merck.github.io/forestly/articles/forestly.html): [Interactive forest plot for DMC safety monitoring in clinical trials](https://rinpharma.com/publication/rinpharma_206/)
 
 ## Background
 
@@ -144,7 +144,7 @@ sponsor shall enhance reproducibility.
 - Fixed R version: e.g., R 4.1.0
 - Fixed R package snapshot date: e.g., 2021-08-31
   - [Posit Package Manager](https://packagemanager.posit.co/)
-  - [CRAN Time Machine by MRAN](https://mran.microsoft.com/timemachine)
+  - CRAN Time Machine by MRAN
 - Flexibility of input and output path:
   - Define path as parameter.
 - eCTD deliverables dry-run in Windows environment

--- a/slides/r4csr-gwu.html
+++ b/slides/r4csr-gwu.html
@@ -3802,7 +3802,7 @@ slide:not(.current) .plotly.html-widget{
 
 <ul>
 <li><a href='https://github.com/SafetyGraphics/safetyGraphics' title=''>SafetyGraphics</a></li>
-<li><a href='https://elong0527.github.io/forestly/articles/forestly.html' title=''>forestly</a>: <a href='https://rinpharma.com/publication/rinpharma_206/' title=''>Interactive forest plot for DMC safety monitoring in clinical trials</a></li>
+<li><a href='https://merck.github.io/forestly/articles/forestly.html' title=''>forestly</a>: <a href='https://rinpharma.com/publication/rinpharma_206/' title=''>Interactive forest plot for DMC safety monitoring in clinical trials</a></li>
 </ul></li>
 </ul>
 
@@ -3904,7 +3904,7 @@ slide:not(.current) .plotly.html-widget{
 
 <ul>
 <li><a href='https://packagemanager.posit.co/' title=''>Posit Package Manager</a></li>
-<li><a href='https://mran.microsoft.com/timemachine' title=''>CRAN Time Machine by MRAN</a></li>
+<li>CRAN Time Machine by MRAN</li>
 </ul></li>
 <li>Flexibility of input and output path:
 

--- a/slides/r4csr-psi.Rmd
+++ b/slides/r4csr-psi.Rmd
@@ -133,7 +133,7 @@ As an organization, we need to ensure compliance and reduce the risk of using R 
 
 - R is widely used in visualization
   - [metalite.table1](https://elong0527.github.io/metalite.table1/articles/metalite-table1.html): Interactive demographic table.
-  - [forestly](https://elong0527.github.io/forestly/articles/example.html#construct-interactive-forest-plot-1): [Interactive forest plot for DMC safety monitoring in clinical trials](https://rinpharma.com/publication/rinpharma_206/)
+  - [forestly](https://merck.github.io/forestly/articles/forestly.html): [Interactive forest plot for DMC safety monitoring in clinical trials](https://rinpharma.com/publication/rinpharma_206/)
 
 ## Background
 
@@ -248,7 +248,7 @@ sponsor shall enhance reproducibility.
 - Fixed R version: e.g., R 4.1.0
 - Fixed R package snapshot date: e.g., 2021-08-31
   - [Posit Package Manager](https://packagemanager.posit.co/)
-  - [CRAN Time Machine by MRAN](https://mran.microsoft.com/timemachine)
+  - CRAN Time Machine by MRAN
 - Flexibility of input and output path:
   - Define path as parameter.
 - eCTD deliverables dry-run in Windows environment

--- a/slides/r4csr-psi.html
+++ b/slides/r4csr-psi.html
@@ -3337,7 +3337,7 @@ slides > slide:not(.segue) > hgroup > h2 {
 
 <ul>
 <li><a href='https://elong0527.github.io/metalite.table1/articles/metalite-table1.html' title=''>metalite.table1</a>: Interactive demographic table.</li>
-<li><a href='https://elong0527.github.io/forestly/articles/example.html#construct-interactive-forest-plot-1' title=''>forestly</a>: <a href='https://rinpharma.com/publication/rinpharma_206/' title=''>Interactive forest plot for DMC safety monitoring in clinical trials</a></li>
+<li><a href='https://merck.github.io/forestly/articles/forestly.html' title=''>forestly</a>: <a href='https://rinpharma.com/publication/rinpharma_206/' title=''>Interactive forest plot for DMC safety monitoring in clinical trials</a></li>
 </ul></li>
 </ul>
 
@@ -3483,7 +3483,7 @@ slides > slide:not(.segue) > hgroup > h2 {
 
 <ul>
 <li><a href='https://packagemanager.posit.co/' title=''>Posit Package Manager</a></li>
-<li><a href='https://mran.microsoft.com/timemachine' title=''>CRAN Time Machine by MRAN</a></li>
+<li>CRAN Time Machine by MRAN</li>
 </ul></li>
 <li>Flexibility of input and output path:
 

--- a/slides/r4csr-rstudio.Rmd
+++ b/slides/r4csr-rstudio.Rmd
@@ -135,7 +135,7 @@ As an organization, we need to ensure compliance and reduce the risk of using R 
 
 - R is widely used in visualization
   - [SafetyGraphics](https://github.com/SafetyGraphics/safetyGraphics)
-  - [forestly](https://elong0527.github.io/forestly/articles/example.html#construct-interactive-forest-plot-1): [Interactive forest plot for DMC safety monitoring in clinical trials](https://rinpharma.com/publication/rinpharma_206/)
+  - [forestly](https://merck.github.io/forestly/articles/forestly.html): [Interactive forest plot for DMC safety monitoring in clinical trials](https://rinpharma.com/publication/rinpharma_206/)
 
 ## Background
 
@@ -238,7 +238,7 @@ sponsor shall enhance reproducibility.
 - Fixed R version: e.g., R 4.1.0
 - Fixed R package snapshot date: e.g., 2021-08-31
   - [Posit Package Manager](https://packagemanager.posit.co/)
-  - [CRAN Time Machine by MRAN](https://mran.microsoft.com/timemachine)
+  - CRAN Time Machine by MRAN
 - Flexibility of input and output path:
   - Define path as parameter.
 - eCTD deliverables dry-run in Windows environment

--- a/slides/r4csr-rstudio.html
+++ b/slides/r4csr-rstudio.html
@@ -3337,7 +3337,7 @@ slides > slide:not(.segue) > hgroup > h2 {
 
 <ul>
 <li><a href='https://github.com/SafetyGraphics/safetyGraphics' title=''>SafetyGraphics</a></li>
-<li><a href='https://elong0527.github.io/forestly/articles/example.html#construct-interactive-forest-plot-1' title=''>forestly</a>: <a href='https://rinpharma.com/publication/rinpharma_206/' title=''>Interactive forest plot for DMC safety monitoring in clinical trials</a></li>
+<li><a href='https://merck.github.io/forestly/articles/forestly.html' title=''>forestly</a>: <a href='https://rinpharma.com/publication/rinpharma_206/' title=''>Interactive forest plot for DMC safety monitoring in clinical trials</a></li>
 </ul></li>
 </ul>
 
@@ -3467,7 +3467,7 @@ slides > slide:not(.segue) > hgroup > h2 {
 
 <ul>
 <li><a href='https://packagemanager.posit.co/' title=''>Posit Package Manager</a></li>
-<li><a href='https://mran.microsoft.com/timemachine' title=''>CRAN Time Machine by MRAN</a></li>
+<li>CRAN Time Machine by MRAN</li>
 </ul></li>
 <li>Flexibility of input and output path:
 

--- a/tlf-overview.qmd
+++ b/tlf-overview.qmd
@@ -11,7 +11,7 @@ of clinical development.
 The [Electronic Common Technical Document (eCTD)](https://en.wikipedia.org/wiki/Electronic_common_technical_document)
 has emerged as the global standard format for regulatory submissions.
 For instance, the United States Food and Drug Administration (US FDA)
-[mandates the use of eCTD]((https://www.fda.gov/drugs/electronic-regulatory-submission-and-review/electronic-common-technical-document-ectd))
+[mandates the use of eCTD](https://www.fda.gov/drugs/electronic-regulatory-submission-and-review/electronic-common-technical-document-ectd)
 for new drug applications and biologics license applications.
 
 A CSR provides comprehensive information about the methods and results of an


### PR DESCRIPTION
This PR updates the forestly URLs and removes obsolete MRAN URLs (now completely retired hence not accessible) in the chapters and slides.