### PR TITLE
Update R submission site URL

### DIFF
--- a/slides/china-r.Rmd
+++ b/slides/china-r.Rmd
@@ -232,7 +232,7 @@ More details: <https://r4csr.org/project-management.html>
   - Presentations: <https://www.pharmar.org/present/>
 
 - R-based submission pilots to FDA:
-  - <https://rconsortium.github.io/r-submission-site/>
+  - <https://rconsortium.github.io/submissions-wg/>
   - Focus on improving practices of R-based clinical trial regulatory submission.
 
 - R/Pharma: <https://rinpharma.com/>

--- a/slides/china-r.html
+++ b/slides/china-r.html
@@ -3983,7 +3983,7 @@ pack(
 <li>R-based submission pilots to FDA:
 
 <ul>
-<li><a href='https://rconsortium.github.io/r-submission-site/' title=''>https://rconsortium.github.io/r-submission-site/</a></li>
+<li><a href='https://rconsortium.github.io/submissions-wg/' title=''>https://rconsortium.github.io/submissions-wg/</a></li>
 <li>Focus on improving practices of R-based clinical trial regulatory submission.</li>
 </ul></li>
 <li>R/Pharma: <a href='https://rinpharma.com/' title=''>https://rinpharma.com/</a>

--- a/slides/r4csr-gwu.Rmd
+++ b/slides/r4csr-gwu.Rmd
@@ -301,7 +301,7 @@ More details: <https://r4csr.org/project-management.html>
   - Presentations: <https://www.pharmar.org/present/>
 
 - R-based submission pilots to FDA:
-  - <https://rconsortium.github.io/r-submission-site/>
+  - <https://rconsortium.github.io/submissions-wg/>
   - Focus on improving practices of R-based clinical trial regulatory submission.
 
 - R/Pharma: <https://rinpharma.com/>

--- a/slides/r4csr-gwu.html
+++ b/slides/r4csr-gwu.html
@@ -4076,7 +4076,7 @@ pack(
 <li>R-based submission pilots to FDA:
 
 <ul>
-<li><a href='https://rconsortium.github.io/r-submission-site/' title=''>https://rconsortium.github.io/r-submission-site/</a></li>
+<li><a href='https://rconsortium.github.io/submissions-wg/' title=''>https://rconsortium.github.io/submissions-wg/</a></li>
 <li>Focus on improving practices of R-based clinical trial regulatory submission.</li>
 </ul></li>
 <li>R/Pharma: <a href='https://rinpharma.com/' title=''>https://rinpharma.com/</a>

--- a/slides/r4csr-psi.Rmd
+++ b/slides/r4csr-psi.Rmd
@@ -337,7 +337,7 @@ More details: <https://r4csr.org/project-management.html>
   - Presentations: <https://www.pharmar.org/present/>
 
 - R-based submission pilots to FDA:
-  - <https://rconsortium.github.io/r-submission-site/>
+  - <https://rconsortium.github.io/submissions-wg/>
   - Focus on improving practices of R-based clinical trial regulatory submission.
 
 - R/Pharma: <https://rinpharma.com/>

--- a/slides/r4csr-psi.html
+++ b/slides/r4csr-psi.html
@@ -3588,7 +3588,7 @@ pack(
 <li>R-based submission pilots to FDA:
 
 <ul>
-<li><a href='https://rconsortium.github.io/r-submission-site/' title=''>https://rconsortium.github.io/r-submission-site/</a></li>
+<li><a href='https://rconsortium.github.io/submissions-wg/' title=''>https://rconsortium.github.io/submissions-wg/</a></li>
 <li>Focus on improving practices of R-based clinical trial regulatory submission.</li>
 </ul></li>
 <li>R/Pharma: <a href='https://rinpharma.com/' title=''>https://rinpharma.com/</a>

--- a/slides/r4csr-rstudio.Rmd
+++ b/slides/r4csr-rstudio.Rmd
@@ -369,7 +369,7 @@ More details: <https://r4csr.org/project-management.html>
   - Presentations: <https://www.pharmar.org/present/>
 
 - R-based submission pilots to FDA:
-  - <https://rconsortium.github.io/r-submission-site/>
+  - <https://rconsortium.github.io/submissions-wg/>
   - Focus on improving practices of R-based clinical trial regulatory submission.
 
 - R/Pharma: <https://rinpharma.com/>

--- a/slides/r4csr-rstudio.html
+++ b/slides/r4csr-rstudio.html
@@ -3614,7 +3614,7 @@ pack(
 <li>R-based submission pilots to FDA:
 
 <ul>
-<li><a href='https://rconsortium.github.io/r-submission-site/' title=''>https://rconsortium.github.io/r-submission-site/</a></li>
+<li><a href='https://rconsortium.github.io/submissions-wg/' title=''>https://rconsortium.github.io/submissions-wg/</a></li>
 <li>Focus on improving practices of R-based clinical trial regulatory submission.</li>
 </ul></li>
 <li>R/Pharma: <a href='https://rinpharma.com/' title=''>https://rinpharma.com/</a>


### PR DESCRIPTION
It looks like the "R submission site" [repo](https://github.com/RConsortium/r-submission-site) has been archived:

> This repository has been archived by the owner on Nov 30, 2023. It is now read-only.

and the [site](https://rconsortium.github.io/r-submission-site/) linked in some slides returns a 404 now.

Perhaps the pages have been moved to the R submission working group [website](https://rconsortium.github.io/submissions-wg/). So I made the updates.