### PR TITLE
Fix undefined control sequence `\cellcolor` error

### DIFF
--- a/.github/workflows/quarto-publish.yml
+++ b/.github/workflows/quarto-publish.yml
@@ -1,15 +1,22 @@
 on:
   push:
-    branches: [master, main]
+    branches:
+      - main
 
 name: Render and Publish
+
+# Need these permissions to publish to GitHub Pages
+permissions:
+  contents: write
+  pages: write
 
 jobs:
   build-deploy:
     runs-on: ubuntu-latest
+
     steps:
       - name: Check out repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Quarto
         uses: quarto-dev/quarto-actions/setup@v2
@@ -19,7 +26,7 @@ jobs:
           # uncomment below and fill to pin a version
           # version: SPECIFIC-QUARTO-VERSION-HERE
 
-      # add software dependencies here
+      # Add software dependencies here
       - name: Install ttf-mscorefonts-installer
         run: |
           echo ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula select true | sudo debconf-set-selections
@@ -36,7 +43,7 @@ jobs:
       - name: Set up R packages in DESCRIPTION
         uses: r-lib/actions/setup-r-dependencies@v2
 
-      # To publish to Netlify, RStudio Connect, or GitHub Pages, uncomment
+      # To publish to Netlify, Posit Connect, or GitHub Pages, uncomment
       # the appropriate block below
 
       # - name: Publish to Netlify (and render)
@@ -45,16 +52,17 @@ jobs:
       #     target: netlify
       #     NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
 
-      # - name: Publish to RStudio Connect (and render)
+      # - name: Publish to Posit Connect (and render)
       #   uses: quarto-dev/quarto-actions/publish@v2
       #   with:
       #     target: connect
       #     CONNECT_SERVER: enter-the-server-url-here
       #     CONNECT_API_KEY: ${{ secrets.CONNECT_API_KEY }}
 
+      # NOTE: If Publishing to GitHub Pages, set the permissions correctly (see top of this yaml)
       - name: Publish to GitHub Pages (and render)
         uses: quarto-dev/quarto-actions/publish@v2
         with:
           target: gh-pages
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # this secret is always available for github actions
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This secret is always available for GitHub Actions

--- a/_quarto.yml
+++ b/_quarto.yml
@@ -78,3 +78,7 @@ format:
     theme: [cosmo, custom.scss]
   pdf:
     documentclass: scrbook
+    # Fixes 'Undefined control sequence \cellcolor' error
+    include-in-header:
+      - text: |
+          \usepackage[table]{xcolor}


### PR DESCRIPTION
## Problem

This error about undefined `\cellcolor` comes from xelatex when building the PDF book:

```
ERROR:
compilation failed- error
Undefined control sequence.
l.3630 fmt\_ci & 3 & Alice & \cellcolor
                                       [HTML]{00ff00}{C} & Alice & \cellcolo...
```

The table is generated by kableExtra and will surely need some refactor since it has not been rendered properly in PDF ever (too wide, with HTML tags, ...).

## Solution

As suggested by StackOverflow, the simple solution is to add the `table` option when using xcolor:

```latex
\usepackage[table]{xcolor}
```

I checked the existing `.tex` output. It has only `\usepackage{xcolor}`. Making this change solved the issue.

Previously, this hasn't been a problem. So I think something upstream might have changed and now we need to use this option explicitly.

---

This PR also updates the GitHub Actions workflow to keep in sync with upstream.